### PR TITLE
Implement modal for team member details

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@ html, body { scroll-behavior: smooth; }
 .brand:hover::after { opacity: 1; }
 .dot { height: 6px; border-radius: 999px; transition: width .25s ease, background-color .25s ease, opacity .25s ease; }
 .hover-shimmer:hover::after{ content:""; pointer-events:none; position:absolute; inset:0; background: radial-gradient(400px 60px at 0% 0%, rgba(0,0,0,.04), transparent); opacity:1; }
+.team-modal{ transition: opacity .25s ease; }
+.team-modal[aria-hidden="true"] .team-modal__panel{ transform: translateY(16px); opacity: 0; }
+.team-modal[aria-hidden="false"] .team-modal__panel{ transform: none; opacity: 1; }
 </style>
 </head>
 <body class="min-h-dvh bg-white text-neutral-900 selection:bg-black selection:text-white">
@@ -499,67 +502,109 @@ function renderInfoSection(title, items){
     </div>
   `;
 }
+function renderMemberDetail(member){
+  if (!member) return '';
+  const badges = (member.badges || []).map(text => `<span class="inline-flex items-center rounded-full border border-black/10 bg-white/80 px-3 py-1 text-xs font-medium text-black/70">${text}</span>`).join('');
+  const highlightChips = (member.highlights || []).map(text => `<span class="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs text-emerald-900">${text}</span>`).join('');
+  return `
+    <article class="space-y-6">
+      <header class="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h3 class="text-2xl font-semibold tracking-tight">${member.name}</h3>
+          <div class="mt-1 text-sm text-black/60">${member.title} · ${member.summary}</div>
+        </div>
+        ${badges ? `<div class="flex flex-wrap gap-2">${badges}</div>` : ''}
+      </header>
+      ${highlightChips ? `<div class="flex flex-wrap gap-2">${highlightChips}</div>` : ''}
+      <div class="grid gap-4 md:grid-cols-2">
+        ${renderInfoSection('Образование', member.education)}
+        ${renderInfoSection('Опыт и роли', member.experience)}
+        ${renderInfoSection('Компетенции', member.competencies)}
+        ${renderInfoSection('Инструменты и ПО', member.software)}
+        ${renderInfoSection('Достижения', member.achievements)}
+        ${renderInfoSection('Материалы и контакты', member.resources)}
+      </div>
+      ${member.interests ? `<p class="text-sm text-black/60">${member.interests}</p>` : ''}
+    </article>
+  `;
+}
 function renderTeam(){
   const cardsRoot = document.getElementById('teamCards');
   const detailRoot = document.getElementById('teamDetail');
   if (!cardsRoot || !detailRoot || !teamMembers.length) return;
-  let activeId = teamMembers[0].id;
   cardsRoot.innerHTML = '';
-  teamMembers.forEach(member => {
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.dataset.person = member.id;
-    btn.className = 'group flex h-full flex-col rounded-2xl border border-black/10 bg-white/70 p-5 text-left transition hover:-translate-y-1 hover:shadow-soft';
-    btn.innerHTML = `
-      <div class="text-sm opacity-60">${member.title}</div>
-      <div class="mt-1 text-lg font-semibold leading-snug">${member.name}</div>
-      <p class="mt-3 text-sm text-black/70">${member.summary}</p>
-      <ul class="mt-4 space-y-1 text-xs text-black/60">
-        ${(member.cardPoints || []).map(point => `<li class="relative pl-3 leading-snug before:absolute before:left-0 before:top-1.5 before:h-1 before:w-1 before:rounded-full before:bg-black/30">${point}</li>`).join('')}
-      </ul>
-      <span class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-black/70 transition group-hover:text-black">Подробнее<span aria-hidden>→</span></span>
-    `;
-    btn.addEventListener('click', () => {
-      activeId = member.id;
-      update();
-      btn.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-    });
-    cardsRoot.appendChild(btn);
-  });
-  function update(){
-    const member = teamMembers.find(p => p.id === activeId) || teamMembers[0];
-    $$('#teamCards button').forEach(btn => {
-      const isActive = btn.dataset.person === member.id;
-      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-      btn.classList.toggle('ring-1', isActive);
-      btn.classList.toggle('ring-black/20', isActive);
-    });
-    if (!member) return;
-    const badges = (member.badges || []).map(text => `<span class="inline-flex items-center rounded-full border border-black/10 bg-white/80 px-3 py-1 text-xs font-medium text-black/70">${text}</span>`).join('');
-    const highlightChips = (member.highlights || []).map(text => `<span class="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs text-emerald-900">${text}</span>`).join('');
-    detailRoot.innerHTML = `
-      <article class="rounded-3xl border border-black/10 bg-white/80 p-6 shadow-soft-md">
-        <div class="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <h3 class="text-2xl font-semibold tracking-tight">${member.name}</h3>
-            <div class="mt-1 text-sm text-black/60">${member.title} · ${member.summary}</div>
-          </div>
-          <div class="flex flex-wrap gap-2">${badges}</div>
-        </div>
-        ${highlightChips ? `<div class="mt-4 flex flex-wrap gap-2">${highlightChips}</div>` : ''}
-        <div class="mt-6 grid gap-4 md:grid-cols-2">
-          ${renderInfoSection('Образование', member.education)}
-          ${renderInfoSection('Опыт и роли', member.experience)}
-          ${renderInfoSection('Компетенции', member.competencies)}
-          ${renderInfoSection('Инструменты и ПО', member.software)}
-          ${renderInfoSection('Достижения', member.achievements)}
-          ${renderInfoSection('Материалы и контакты', member.resources)}
-        </div>
-        ${member.interests ? `<p class="mt-6 text-sm text-black/60">${member.interests}</p>` : ''}
-      </article>
-    `;
+  detailRoot.innerHTML = `
+    <div data-team-overlay class="team-modal pointer-events-none fixed inset-0 z-[70] flex items-center justify-center px-4 py-8 opacity-0" aria-hidden="true">
+      <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" data-team-dismiss></div>
+      <div class="team-modal__panel relative w-full max-w-4xl overflow-hidden rounded-3xl border border-black/10 bg-white shadow-soft-md transition duration-300">
+        <button type="button" class="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full border border-black/10 bg-white/80 text-black/60 transition hover:border-black/20 hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20" aria-label="Закрыть" data-team-dismiss data-team-close>
+          <svg viewBox="0 0 24 24" aria-hidden="true" class="h-5 w-5"><path d="M7 7l10 10m0-10L7 17" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+        </button>
+        <div data-team-modal-content class="max-h-[80vh] overflow-y-auto px-6 py-6 sm:max-h-[75vh] sm:px-8 sm:py-8"></div>
+      </div>
+    </div>
+  `;
+  const overlay = detailRoot.querySelector('[data-team-overlay]');
+  const modalContent = detailRoot.querySelector('[data-team-modal-content]');
+  const closeButtons = detailRoot.querySelectorAll('[data-team-dismiss]');
+  let lastTrigger = null;
+  function closeModal(){
+    overlay?.setAttribute('aria-hidden', 'true');
+    overlay?.classList.remove('opacity-100', 'pointer-events-auto');
+    overlay?.classList.add('opacity-0', 'pointer-events-none');
+    document.body.classList.remove('overflow-hidden');
+    if (lastTrigger){
+      lastTrigger.focus({ preventScroll: true });
+      lastTrigger = null;
+    }
   }
-  update();
+  function openModal(member, trigger){
+    if (!overlay || !modalContent) return;
+    modalContent.innerHTML = renderMemberDetail(member);
+    overlay.setAttribute('aria-hidden', 'false');
+    overlay.classList.remove('opacity-0', 'pointer-events-none');
+    overlay.classList.add('opacity-100', 'pointer-events-auto');
+    document.body.classList.add('overflow-hidden');
+    if (trigger instanceof HTMLElement){
+      lastTrigger = trigger;
+    }
+    const closeBtn = overlay.querySelector('[data-team-close]');
+    closeBtn?.focus({ preventScroll: true });
+  }
+  closeButtons.forEach(btn => btn.addEventListener('click', closeModal));
+  overlay?.addEventListener('click', (event) => {
+    if (event.target === overlay) closeModal();
+  });
+  const handleKeydown = (event) => {
+    if (event.key === 'Escape' && overlay?.getAttribute('aria-hidden') === 'false'){
+      event.preventDefault();
+      closeModal();
+    }
+  };
+  if (!document.body.dataset.teamModalEscape){
+    document.body.dataset.teamModalEscape = 'bound';
+    document.addEventListener('keydown', handleKeydown);
+  }
+  teamMembers.forEach(member => {
+    const card = document.createElement('article');
+    card.className = 'group flex h-full flex-col justify-between gap-5 rounded-2xl border border-black/10 bg-white/70 p-5 transition hover:-translate-y-1 hover:shadow-soft';
+    card.innerHTML = `
+      <div>
+        <div class="text-sm opacity-60">${member.title}</div>
+        <div class="mt-1 text-lg font-semibold leading-snug">${member.name}</div>
+        <p class="mt-3 text-sm text-black/70">${member.summary}</p>
+        <ul class="mt-4 space-y-1 text-xs text-black/60">
+          ${(member.cardPoints || []).map(point => `<li class="relative pl-3 leading-snug before:absolute before:left-0 before:top-1.5 before:h-1 before:w-1 before:rounded-full before:bg-black/30">${point}</li>`).join('')}
+        </ul>
+      </div>
+      <button type="button" class="mt-5 inline-flex w-full items-center justify-between gap-2 rounded-xl border border-black/10 px-4 py-2 text-sm font-medium text-black/70 transition hover:bg-black hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20" data-team-open>
+        <span>Подробнее</span>
+        <span aria-hidden class="transition group-hover:translate-x-0.5">→</span>
+      </button>
+    `;
+    card.querySelector('[data-team-open]')?.addEventListener('click', (event) => openModal(member, event.currentTarget));
+    cardsRoot.appendChild(card);
+  });
 }
 function renderTeamShowcase(){
   const rail = document.getElementById('teamShowcaseRail');


### PR DESCRIPTION
## Summary
- add modal transition styling to support animated team detail overlays
- refactor the team section to open teacher information in a responsive modal with clear "Подробнее" triggers and multiple close affordances

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d00339b85c83338e02ce8ed9ebf55b