### PR TITLE
Improve accessibility of team modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -502,15 +502,22 @@ function renderInfoSection(title, items){
     </div>
   `;
 }
+function getMemberHeadingId(member){
+  if (member && member.id){
+    return `team-member-${member.id}-title`;
+  }
+  return 'team-member-detail-title';
+}
 function renderMemberDetail(member){
   if (!member) return '';
   const badges = (member.badges || []).map(text => `<span class="inline-flex items-center rounded-full border border-black/10 bg-white/80 px-3 py-1 text-xs font-medium text-black/70">${text}</span>`).join('');
   const highlightChips = (member.highlights || []).map(text => `<span class="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs text-emerald-900">${text}</span>`).join('');
+  const headingId = getMemberHeadingId(member);
   return `
     <article class="space-y-6">
       <header class="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h3 class="text-2xl font-semibold tracking-tight">${member.name}</h3>
+          <h3 id="${headingId}" class="text-2xl font-semibold tracking-tight">${member.name}</h3>
           <div class="mt-1 text-sm text-black/60">${member.title} · ${member.summary}</div>
         </div>
         ${badges ? `<div class="flex flex-wrap gap-2">${badges}</div>` : ''}
@@ -536,23 +543,41 @@ function renderTeam(){
   detailRoot.innerHTML = `
     <div data-team-overlay class="team-modal pointer-events-none fixed inset-0 z-[70] flex items-center justify-center px-4 py-8 opacity-0" aria-hidden="true">
       <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" data-team-dismiss></div>
-      <div class="team-modal__panel relative w-full max-w-4xl overflow-hidden rounded-3xl border border-black/10 bg-white shadow-soft-md transition duration-300">
+      <div class="team-modal__panel relative w-full max-w-4xl overflow-hidden rounded-3xl border border-black/10 bg-white shadow-soft-md transition duration-300" role="dialog" aria-modal="true" aria-labelledby="" tabindex="-1" data-team-dialog>
         <button type="button" class="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full border border-black/10 bg-white/80 text-black/60 transition hover:border-black/20 hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20" aria-label="Закрыть" data-team-dismiss data-team-close>
           <svg viewBox="0 0 24 24" aria-hidden="true" class="h-5 w-5"><path d="M7 7l10 10m0-10L7 17" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
         </button>
         <div data-team-modal-content class="max-h-[80vh] overflow-y-auto px-6 py-6 sm:max-h-[75vh] sm:px-8 sm:py-8"></div>
+        <p class="sr-only" aria-live="polite" data-team-announcer></p>
       </div>
     </div>
   `;
   const overlay = detailRoot.querySelector('[data-team-overlay]');
   const modalContent = detailRoot.querySelector('[data-team-modal-content]');
+  const panel = detailRoot.querySelector('[data-team-dialog]');
+  const announcer = detailRoot.querySelector('[data-team-announcer]');
+  if (panel){
+    panel.setAttribute('aria-hidden', 'true');
+  }
   const closeButtons = detailRoot.querySelectorAll('[data-team-dismiss]');
   let lastTrigger = null;
+  let focusableElements = [];
+  let focusTrapHandler = null;
   function closeModal(){
     overlay?.setAttribute('aria-hidden', 'true');
+    panel?.setAttribute('aria-hidden', 'true');
+    panel?.removeAttribute('aria-labelledby');
     overlay?.classList.remove('opacity-100', 'pointer-events-auto');
     overlay?.classList.add('opacity-0', 'pointer-events-none');
     document.body.classList.remove('overflow-hidden');
+    if (panel && focusTrapHandler){
+      panel.removeEventListener('keydown', focusTrapHandler);
+    }
+    focusTrapHandler = null;
+    focusableElements = [];
+    if (announcer){
+      announcer.textContent = '';
+    }
     if (lastTrigger){
       lastTrigger.focus({ preventScroll: true });
       lastTrigger = null;
@@ -561,6 +586,11 @@ function renderTeam(){
   function openModal(member, trigger){
     if (!overlay || !modalContent) return;
     modalContent.innerHTML = renderMemberDetail(member);
+    const headingId = getMemberHeadingId(member);
+    if (panel){
+      panel.setAttribute('aria-labelledby', headingId);
+      panel.setAttribute('aria-hidden', 'false');
+    }
     overlay.setAttribute('aria-hidden', 'false');
     overlay.classList.remove('opacity-0', 'pointer-events-none');
     overlay.classList.add('opacity-100', 'pointer-events-auto');
@@ -568,8 +598,40 @@ function renderTeam(){
     if (trigger instanceof HTMLElement){
       lastTrigger = trigger;
     }
+    if (announcer){
+      announcer.textContent = member?.name || '';
+    }
+    if (panel){
+      focusableElements = Array.from(panel.querySelectorAll('a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'))
+        .filter(el => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true');
+      focusTrapHandler = (event) => {
+        if (event.key !== 'Tab') return;
+        if (!focusableElements.length){
+          event.preventDefault();
+          panel.focus({ preventScroll: true });
+          return;
+        }
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+        const activeElement = document.activeElement;
+        if (event.shiftKey){
+          if (activeElement === firstElement || !panel.contains(activeElement)){
+            event.preventDefault();
+            lastElement.focus({ preventScroll: true });
+          }
+        } else if (activeElement === lastElement){
+          event.preventDefault();
+          firstElement.focus({ preventScroll: true });
+        }
+      };
+      panel.addEventListener('keydown', focusTrapHandler);
+    }
     const closeBtn = overlay.querySelector('[data-team-close]');
-    closeBtn?.focus({ preventScroll: true });
+    if (closeBtn){
+      closeBtn.focus({ preventScroll: true });
+    } else if (panel){
+      panel.focus({ preventScroll: true });
+    }
   }
   closeButtons.forEach(btn => btn.addEventListener('click', closeModal));
   overlay?.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- add explicit dialog semantics to the team modal and announce the selected member for assistive tech
- implement focus management with a simple focus trap and restore aria attributes on close

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0099500188333bd71ab612f4e1290