### PR TITLE
Improve apply form accessibility and submission UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,21 @@ html, body { scroll-behavior: smooth; }
 .team-modal{ transition: opacity .25s ease; }
 .team-modal[aria-hidden="true"] .team-modal__panel{ transform: translateY(16px); opacity: 0; }
 .team-modal[aria-hidden="false"] .team-modal__panel{ transform: none; opacity: 1; }
+@keyframes submit-spinner{ to{ transform: rotate(360deg); } }
+#submitBtn[data-busy="true"]{ cursor: wait; pointer-events: none; }
+#submitBtn[data-busy="true"]::after{
+  content:"";
+  display:inline-block;
+  margin-left:0.75rem;
+  height:1rem;
+  width:1rem;
+  border-radius:999px;
+  border:2px solid rgba(255,255,255,.6);
+  border-top-color:transparent;
+  vertical-align:middle;
+  animation: submit-spinner .6s linear infinite;
+}
+#applyForm.is-submitting{ opacity:.97; }
 </style>
 </head>
 <body class="min-h-dvh bg-white text-neutral-900 selection:bg-black selection:text-white">
@@ -130,13 +145,13 @@ html, body { scroll-behavior: smooth; }
           Имя и фамилия
           <input name="name" autocomplete="name" required placeholder="Иван Иванов"
                  class="rounded-xl border border-black/10 px-3 py-2 outline-none focus-visible:ring-2 focus-visible:ring-black/30"/>
-          <span class="hidden text-xs text-red-600" data-err="name"></span>
+          <span id="error-name" class="hidden text-xs text-red-600" data-err="name"></span>
         </label>
         <label class="flex flex-col gap-1 text-sm">
           Электронная почта
           <input name="email" type="email" autocomplete="email" required placeholder="name@example.com"
                  class="rounded-xl border border-black/10 px-3 py-2 outline-none focus-visible:ring-2 focus-visible:ring-black/30"/>
-          <span class="hidden text-xs text-red-600" data-err="email"></span>
+          <span id="error-email" class="hidden text-xs text-red-600" data-err="email"></span>
         </label>
         <label class="md:col-span-2 flex flex-col gap-1 text-sm">
           Комментарий
@@ -147,14 +162,16 @@ html, body { scroll-behavior: smooth; }
           <input name="agree" type="checkbox" class="mt-1 h-4 w-4 rounded border-black/20 outline-none focus-visible:ring-2 focus-visible:ring-black/30"/>
           <span>Согласен(а) на обработку персональных данных и условия политики конфиденциальности.</span>
         </label>
-        <span class="hidden text-xs text-red-600 md:col-span-2" data-err="agree"></span>
+        <span id="error-agree" class="hidden text-xs text-red-600 md:col-span-2" data-err="agree"></span>
       </div>
       <div class="mt-4 flex flex-wrap items-center gap-3">
         <button type="submit" id="submitBtn" disabled
-                class="cursor-not-allowed rounded-xl bg-black/30 px-4 py-2 text-white outline-none transition focus-visible:ring-2 focus-visible:ring-black/30">Отправить заявку</button>
+                class="relative rounded-xl bg-black/30 px-4 py-2 text-white outline-none transition focus-visible:ring-2 focus-visible:ring-black/30 cursor-not-allowed disabled:cursor-not-allowed">Отправить заявку</button>
         <span class="inline-flex items-center gap-2 rounded-full border border-black/10 px-3 py-1 text-sm">Стоимость: <span class="font-medium" id="leadPriceInline"></span></span>
         <span class="inline-flex items-center gap-2 rounded-full border border-black/10 px-3 py-1 text-sm">Адрес: <span class="font-medium">Москва, ул. Беговая, д. 12 (лаборатория промдизайна). Итоговое занятие (суббота): Москва, ул. Вильгельма Пика, д. 4, к. 8 (технопарк РГСУ)</span></span>
       </div>
+      <div id="applyFormStatus" class="mt-4 hidden rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800" role="status" aria-live="polite" tabindex="-1"></div>
+      <div id="applyFormError" class="mt-2 hidden rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-800" role="alert" tabindex="-1"></div>
     </form>
     <div class="mt-4 space-y-2 text-xs opacity-70">
       <p>Нажимая кнопку «Отправить заявку», вы даёте <span class="underline">согласие на обработку персональных данных</span> и подтверждаете ознакомление с политикой конфиденциальности.</p>
@@ -894,7 +911,11 @@ function initCountdown(){
 function initForm(){
   const form = document.getElementById('applyForm');
   const submitBtn = document.getElementById('submitBtn');
+  const successStatus = document.getElementById('applyFormStatus');
+  const errorStatus = document.getElementById('applyFormError');
   const storageKey = 'applyForm';
+  const submitBaseClasses = 'relative rounded-xl px-4 py-2 text-white outline-none transition focus-visible:ring-2 focus-visible:ring-black/30 disabled:cursor-not-allowed';
+  let statusTimeout;
   try{
     const raw = localStorage.getItem(storageKey);
     if (raw) {
@@ -907,28 +928,94 @@ function initForm(){
       });
     }
   } catch {}
+  function hideSuccessMessage(){
+    if (!successStatus) return;
+    if (statusTimeout){ clearTimeout(statusTimeout); statusTimeout = null; }
+    successStatus.classList.add('hidden');
+    successStatus.textContent = '';
+  }
+  function hideErrorMessage(){
+    if (!errorStatus) return;
+    errorStatus.classList.add('hidden');
+    errorStatus.textContent = '';
+  }
+  function focusStatus(el){
+    if (!el) return;
+    requestAnimationFrame(()=>{ try{ el.focus({ preventScroll: true }); } catch {} });
+  }
+  function showSuccessMessage(msg){
+    if (!successStatus) return;
+    hideErrorMessage();
+    successStatus.textContent = msg;
+    successStatus.classList.remove('hidden');
+    focusStatus(successStatus);
+    if (statusTimeout){ clearTimeout(statusTimeout); }
+    statusTimeout = setTimeout(()=>{ hideSuccessMessage(); }, 6000);
+  }
+  function showErrorMessage(msg){
+    hideSuccessMessage();
+    if (!errorStatus) return;
+    errorStatus.textContent = msg;
+    errorStatus.classList.remove('hidden');
+    focusStatus(errorStatus);
+  }
   function showError(name, msg){
     const err = form.querySelector(`[data-err="${name}"]`);
-    if (!err) return;
-    if (msg){ err.textContent = msg; err.classList.remove('hidden'); }
-    else { err.textContent = ''; err.classList.add('hidden'); }
     const input = form.elements[name];
+    const errId = err && err.id ? err.id : null;
+    if (err){
+      if (msg){ err.textContent = msg; err.classList.remove('hidden'); }
+      else { err.textContent = ''; err.classList.add('hidden'); }
+    }
     if (input){
-      if (msg) input.classList.add('border-red-400');
-      else input.classList.remove('border-red-400');
+      const described = new Set((input.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean));
+      if (msg){
+        input.classList.add('border-red-400');
+        input.setAttribute('aria-invalid','true');
+        if (errId) described.add(errId);
+      } else {
+        input.classList.remove('border-red-400');
+        input.removeAttribute('aria-invalid');
+        if (errId) described.delete(errId);
+      }
+      if (described.size){ input.setAttribute('aria-describedby', Array.from(described).join(' ')); }
+      else { input.removeAttribute('aria-describedby'); }
     }
   }
   function validate(silent=false){
     const name = form.elements.name.value.trim();
     const email = form.elements.email.value.trim();
     const agree = form.elements.agree.checked;
-    let ok = true;
-    if (name.split(/\s+/).length < 2){ ok=false; if(!silent) showError('name','Укажите имя и фамилию'); } else if(!silent) showError('name', '');
-    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)){ ok=false; if(!silent) showError('email','Проверьте формат e-mail'); } else if(!silent) showError('email','');
-    if (!agree){ ok=false; if(!silent) showError('agree','Нужно согласие на обработку данных'); } else if(!silent) showError('agree','');
-    submitBtn.disabled = !ok;
-    submitBtn.className = 'rounded-xl px-4 py-2 text-white outline-none transition focus-visible:ring-2 focus-visible:ring-black/30 ' + (ok ? 'bg-black hover:opacity-90' : 'bg-black/30 cursor-not-allowed');
-    return ok;
+    const result = { ok: true, invalid: [] };
+    if (name.split(/\s+/).length < 2){
+      result.ok = false;
+      result.invalid.push(form.elements.name);
+      if (!silent) showError('name','Укажите имя и фамилию');
+    } else {
+      showError('name','');
+    }
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)){
+      result.ok = false;
+      result.invalid.push(form.elements.email);
+      if (!silent) showError('email','Проверьте формат e-mail');
+    } else {
+      showError('email','');
+    }
+    if (!agree){
+      result.ok = false;
+      result.invalid.push(form.elements.agree);
+      if (!silent) showError('agree','Нужно согласие на обработку данных');
+    } else {
+      showError('agree','');
+    }
+    const isBusy = form.classList.contains('is-submitting');
+    submitBtn.disabled = !result.ok || isBusy;
+    submitBtn.className = submitBaseClasses + (result.ok ? ' bg-black hover:opacity-90' : ' bg-black/30 cursor-not-allowed');
+    return result;
+  }
+  function getInvalidFocus(result){
+    if (!result || !Array.isArray(result.invalid)) return null;
+    return result.invalid.find(el=> el && typeof el.focus === 'function') || null;
   }
   form.addEventListener('input', ()=>{
     const state = {
@@ -938,16 +1025,40 @@ function initForm(){
       agree: form.elements.agree.checked
     };
     try{ localStorage.setItem(storageKey, JSON.stringify(state)); } catch {}
+    hideErrorMessage();
+    hideSuccessMessage();
     validate(true);
   });
   form.addEventListener('blur', (e)=>{ if (e.target && e.target.name) validate(false); }, true);
-  form.addEventListener('submit', (e)=>{
+  form.addEventListener('submit', async (e)=>{
     e.preventDefault();
-    if (!validate(false)) return;
-    alert('Заявка отправлена! Мы свяжемся с вами.');
-    form.reset();
-    try{ localStorage.removeItem(storageKey); } catch {}
-    validate(true);
+    if (form.classList.contains('is-submitting')) return;
+    hideErrorMessage();
+    hideSuccessMessage();
+    const result = validate(false);
+    if (!result.ok){
+      const target = getInvalidFocus(result);
+      if (target){ target.focus(); }
+      return;
+    }
+    form.classList.add('is-submitting');
+    form.setAttribute('aria-busy','true');
+    submitBtn.setAttribute('data-busy','true');
+    submitBtn.disabled = true;
+    try{
+      await new Promise(resolve=> setTimeout(resolve, 600));
+      showSuccessMessage('Заявка отправлена! Мы свяжемся с вами.');
+      form.reset();
+      ['name','email','agree'].forEach(name=> showError(name,''));
+      try{ localStorage.removeItem(storageKey); } catch {}
+    } catch (err){
+      showErrorMessage('Не удалось отправить заявку. Попробуйте ещё раз позже.');
+    } finally {
+      form.classList.remove('is-submitting');
+      form.removeAttribute('aria-busy');
+      submitBtn.removeAttribute('data-busy');
+      validate(true);
+    }
   });
   validate(true);
 }


### PR DESCRIPTION
## Summary
- add explicit ids for error messages, inline status containers, and loading styles to the apply form markup
- enhance validation logic to manage aria attributes, busy state, and focus for the first invalid control
- replace the alert with inline success and error messaging while keeping localStorage in sync during submission

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d009ac5a5883338d1d2b877ff0156f