### PR TITLE
Restore layout without Tailwind CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,24 +38,8 @@
     <link rel="stylesheet" href="styles/tokens.css" />
     <link rel="stylesheet" href="styles/base.css" />
     <link rel="stylesheet" href="styles/components.css" />
+    <link rel="stylesheet" href="styles/utilities.css" />
     <link rel="stylesheet" href="styles/a11y.css" />
-    <link rel="dns-prefetch" href="//cdn.tailwindcss.com" />
-    <link rel="preconnect" href="https://cdn.tailwindcss.com" crossorigin />
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script>
-      /* global tailwind */
-      tailwind.config = {
-        theme: {
-          extend: {
-            borderRadius: { '2xl': '1rem' },
-            boxShadow: {
-              soft: '0 6px 24px rgba(0,0,0,.06)',
-              'soft-md': '0 10px 30px rgba(0,0,0,.08)',
-            },
-          },
-        },
-      };
-    </script>
   </head>
   <body>
     <a class="skip-link" href="#main-content">Перейти к содержимому</a>

--- a/styles/utilities.css
+++ b/styles/utilities.css
@@ -1,0 +1,150 @@
+@layer utilities {
+  .fixed { position: fixed; }
+  .absolute { position: absolute; }
+  .relative { position: relative; }
+  .flex { display: flex; }
+  .inline-flex { display: inline-flex; }
+  .grid { display: grid; }
+  .block { display: block; }
+  .hidden { display: none; }
+  .flex-col { flex-direction: column; }
+  .flex-wrap { flex-wrap: wrap; }
+  .items-center { align-items: center; }
+  .justify-between { justify-content: space-between; }
+  .gap-2 { gap: 0.5rem; }
+  .gap-3 { gap: 0.75rem; }
+  .gap-4 { gap: 1rem; }
+  .space-y-2 > * + * { margin-top: 0.5rem; }
+  .space-y-5 > * + * { margin-top: 1.25rem; }
+  .mt-1 { margin-top: 0.25rem; }
+  .mt-3 { margin-top: 0.75rem; }
+  .mt-4 { margin-top: 1rem; }
+  .mt-6 { margin-top: 1.5rem; }
+  .mt-8 { margin-top: 2rem; }
+  .mb-4 { margin-bottom: 1rem; }
+  .pb-4 { padding-bottom: 1rem; }
+  .pb-16 { padding-bottom: 4rem; }
+  .p-2 { padding: 0.5rem; }
+  .p-6 { padding: 1.5rem; }
+  .px-4 { padding-inline: 1rem; }
+  .py-2 { padding-block: 0.5rem; }
+  .w-full { width: 100%; }
+  .w-4 { width: 1rem; }
+  .w-10 { width: 2.5rem; }
+  .w-72 { width: 18rem; }
+  .min-w-\[2\.5rem\] { min-width: 2.5rem; }
+  .h-full { height: 100%; }
+  .h-0\.5 { height: 0.125rem; }
+  .h-4 { height: 1rem; }
+  .h-10 { height: 2.5rem; }
+  .h-\[2px\] { height: 2px; }
+  .min-h-\[18rem\] { min-height: 18rem; }
+  .max-w-2xl { max-width: 42rem; }
+  .max-w-3xl { max-width: 48rem; }
+  .max-w-\[80vw\] { max-width: 80vw; }
+  .aspect-square { aspect-ratio: 1 / 1; }
+  .overflow-hidden { overflow: hidden; }
+  .overflow-x-auto { overflow-x: auto; }
+  .select-none { user-select: none; }
+  .pointer-events-none { pointer-events: none; }
+  .opacity-0 { opacity: 0; }
+  .opacity-60 { opacity: 0.6; }
+  .opacity-70 { opacity: 0.7; }
+  .opacity-100 { opacity: 1; }
+  .translate-x-full { transform: translateX(100%); }
+  .bg-white { background-color: #fff; }
+  .bg-white\/70 { background-color: rgba(255, 255, 255, 0.7); }
+  .bg-white\/80 { background-color: rgba(255, 255, 255, 0.8); }
+  .bg-black\/40 { background-color: rgba(0, 0, 0, 0.4); }
+  .bg-black\/80 { background-color: rgba(0, 0, 0, 0.8); }
+  .bg-current { background-color: currentColor; }
+  .bg-gradient-to-b {
+    --util-gradient-from: transparent;
+    --util-gradient-to: transparent;
+    background-image: linear-gradient(to bottom, var(--util-gradient-from), var(--util-gradient-to));
+  }
+  .from-neutral-50 { --util-gradient-from: hsl(210 20% 98%); }
+  .to-neutral-100 { --util-gradient-to: hsl(0 0% 100%); }
+  .border { border: 1px solid currentColor; border-color: inherit; }
+  .border-black\/10 { border-color: rgba(0, 0, 0, 0.1); }
+  .rounded-2xl { border-radius: 1rem; }
+  .rounded-3xl { border-radius: 1.5rem; }
+  .rounded-full { border-radius: 9999px; }
+  .ring-1 { box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.5); }
+  .ring-inset { box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.5); }
+  .ring-black\/10 { box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1); }
+  .ring-black\/10.ring-inset { box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1); }
+  .shadow-sm { box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08); }
+  .shadow-xl {
+    box-shadow:
+      0 20px 25px -5px rgba(15, 23, 42, 0.15),
+      0 10px 10px -5px rgba(15, 23, 42, 0.1);
+  }
+  .backdrop-blur { backdrop-filter: blur(16px); }
+  .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
+  .text-xs { font-size: 0.75rem; line-height: 1rem; }
+  .text-2xl { font-size: 1.5rem; line-height: 2rem; }
+  .font-medium { font-weight: 500; }
+  .font-semibold { font-weight: 600; }
+  .uppercase { text-transform: uppercase; }
+  .tracking-tight { letter-spacing: -0.015em; }
+  .tracking-\[\.2em\] { letter-spacing: 0.2em; }
+  .leading-tight { line-height: 1.25; }
+  .text-black { color: #0f172a; }
+  .text-black\/40 { color: rgba(15, 23, 42, 0.4); }
+  .text-black\/60 { color: rgba(15, 23, 42, 0.6); }
+  .text-black\/70 { color: rgba(15, 23, 42, 0.7); }
+  .hover\:underline:hover { text-decoration: underline; }
+  .underline { text-decoration-line: underline; }
+  .underline-offset-2 { text-underline-offset: 0.25rem; }
+  .transition {
+    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 150ms;
+    transition-timing-function: var(--easing-standard);
+  }
+  .transition-opacity {
+    transition-property: opacity;
+    transition-duration: 150ms;
+    transition-timing-function: var(--easing-standard);
+  }
+  .transition-transform {
+    transition-property: transform;
+    transition-duration: 150ms;
+    transition-timing-function: var(--easing-standard);
+  }
+  .duration-200 { transition-duration: 200ms; }
+  .focus\:outline-none:focus,
+  .focus\:outline-none:focus-visible { outline: none; }
+  .scroll-smooth { scroll-behavior: smooth; }
+  .inset-0 { inset: 0; }
+  .left-0 { left: 0; }
+  .right-0 { right: 0; }
+  .top-0 { top: 0; }
+  .z-\[60\] { z-index: 60; }
+  .z-\[70\] { z-index: 70; }
+  .ring-black\/10.ring-1 { box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1); }
+  .ring-black\/10.ring-inset { box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1); }
+  .ring-black\/10.ring-inset.ring-1 { box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1); }
+}
+
+@layer utilities {
+  .grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+}
+
+@media (min-width: 640px) {
+  .sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .sm\:hidden { display: none !important; }
+}
+@media (min-width: 768px) {
+  .md\:flex { display: flex !important; }
+  .md\:hidden { display: none !important; }
+  .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .md\:items-start { align-items: flex-start !important; }
+  .md\:col-span-2 { grid-column: span 2 / span 2; }
+  .md\:text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+}
+@media (min-width: 1024px) {
+  .lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .lg\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}


### PR DESCRIPTION
## Summary
- remove reliance on the Tailwind CDN and link in a local utilities stylesheet
- recreate the required utility classes so cards, grids and navigation recover their intended layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d034f54a80833398e963d864ba48f0