### PR TITLE
Enhance application feedback and assistant panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,17 @@
         transform: none;
         opacity: 1;
       }
+      .feedback-card {
+        opacity: 0;
+        transform: translateY(8px);
+        transition:
+          opacity 0.3s ease,
+          transform 0.3s ease;
+      }
+      .feedback-card[data-state='visible'] {
+        opacity: 1;
+        transform: none;
+      }
       .sr-only {
         position: absolute;
         width: 1px;
@@ -443,10 +454,43 @@
             >Стоимость: <span class="font-medium" id="leadPriceInline"></span
           ></span>
         </div>
+        <div id="applyFeedback" aria-live="polite" class="mt-4 space-y-3"></div>
         <div class="mt-6 grid gap-4 md:grid-cols-2 md:items-start">
           <div id="applyLocations" class="flex flex-col gap-3"></div>
           <div id="applyMap" class="min-h-[18rem]"></div>
         </div>
+        <section
+          id="assistantPanel"
+          class="mt-6 rounded-2xl border border-dashed border-black/10 bg-black/5 p-4 text-sm md:p-5"
+          aria-live="polite"
+        >
+          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h3 class="text-base font-semibold">AI-помощник</h3>
+              <p class="text-black/70">
+                Опишите задачи или интересы — помощник предложит модули курса.
+              </p>
+            </div>
+            <button
+              type="button"
+              id="assistantSuggest"
+              class="mt-2 inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-black shadow-soft transition hover:bg-black hover:text-white md:mt-0"
+            >
+              <span aria-hidden="true">🤖</span>
+              Подобрать модули
+            </button>
+          </div>
+          <label class="mt-3 flex flex-col gap-2">
+            <span class="text-xs uppercase tracking-wide text-black/60">Комментарий для помощника</span>
+            <textarea
+              id="assistantComment"
+              rows="3"
+              class="rounded-xl border border-black/10 bg-white px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-black/30"
+              placeholder="Например: интересуюсь 3D-сканированием и медицинскими кейсами"
+            ></textarea>
+          </label>
+          <div id="assistantOutput" class="mt-4 space-y-3 text-sm"></div>
+        </section>
       </form>
       <div class="mt-4 space-y-2 text-xs opacity-70">
         <p>

--- a/src/utils/assistant.js
+++ b/src/utils/assistant.js
@@ -1,0 +1,76 @@
+const catalog = [
+  {
+    id: 'scan-basics',
+    title: 'Модуль «3D-сканирование и подготовка оборудования»',
+    description:
+      'Разбираемся с калибровкой, выбором сканера и получением точного облака точек для последующей работы.',
+    keywords: ['скан', 'scan', 'цифров', 'облако точек', 'калибр'],
+  },
+  {
+    id: 'cad-reverse',
+    title: 'Модуль «Реверсивный инжиниринг в CAD»',
+    description:
+      'Переносим данные сканирования в CAD, восстанавливаем поверхности, подготавливаем твердотельную модель.',
+    keywords: ['cad', 'reverse', 'реверс', 'поверхност', 'geomagic', 'model'],
+  },
+  {
+    id: 'additive-production',
+    title: 'Модуль «Аддитивное производство и постобработка»',
+    description:
+      'Выбираем технологию печати, подготавливаем G-код и доводим изделия до требуемого состояния.',
+    keywords: ['печать', 'additive', '3d-печать', 'постобработ', 'g-код', 'принтер'],
+  },
+  {
+    id: 'medical',
+    title: 'Практикум «Медицинские кейсы и биопротезирование»',
+    description:
+      'Разбираем реальные кейсы по изготовлению имплантов и биопротезов с учётом требований отрасли.',
+    keywords: ['медицин', 'био', 'имплант', 'протез', 'медицина'],
+  },
+  {
+    id: 'cnc',
+    title: 'Модуль «Подготовка к ЧПУ и изготовление оснастки»',
+    description:
+      'Оптимизируем детали под обработку, учимся готовить управляющие программы и постпроцессинг.',
+    keywords: ['чпу', 'cnc', 'оснаст', 'фрезер', 'станок'],
+  },
+];
+
+const defaultModules = catalog.slice(0, 3);
+
+export function getAssistantRecommendations(comment = '') {
+  try {
+    const normalized = comment.toLocaleLowerCase('ru-RU');
+    const matches = normalized
+      ? catalog.filter((module) =>
+          module.keywords.some((keyword) => normalized.includes(keyword)),
+        )
+      : [];
+
+    if (matches.length > 0) {
+      return {
+        success: true,
+        modules: matches,
+        message: 'Сфокусируйтесь на этих модулях — они лучше всего соответствуют запросу.',
+        fallback: false,
+      };
+    }
+
+    return {
+      success: true,
+      modules: defaultModules,
+      message: normalized
+        ? 'Не нашли точных совпадений, но эти модули помогут закрыть базовые потребности.'
+        : 'Расскажите о целях подробнее или начните с ключевых модулей ниже.',
+      fallback: true,
+    };
+  } catch (error) {
+    console.warn('Assistant logic unavailable', error);
+    return {
+      success: false,
+      modules: defaultModules,
+      message: 'Помощник недоступен. Ниже — основные модули курса.',
+      fallback: true,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add an inline feedback container and AI helper panel to the application form
- replace the alert with an animated toast that summarises the submitted data and persists storage state
- wire in assistant keyword recommendations via a dedicated module with graceful fallbacks

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d04679ea58833390291f29ce738e46