### PR TITLE
Adjust program tabs wrapper responsiveness

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1575,7 +1575,7 @@ function renderProgram() {
     });
   };
   const tabsWrap = document.createElement('div');
-  tabsWrap.className = 'sticky top-16 z-20 border-b border-black/10 bg-white/80 backdrop-blur';
+  tabsWrap.className = 'relative border-b border-black/10 bg-white/80 backdrop-blur md:sticky md:top-16';
   tabsWrap.innerHTML =
     '<div class="overflow-x-auto px-3 py-2"><div class="flex items-stretch gap-3" id="dayTabs"></div></div>';
   root.appendChild(tabsWrap);


### PR DESCRIPTION
## Summary
- update the program tabs wrapper to be relative by default and only sticky from the md breakpoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d04f027cf48333b4a86545e91451e9