### PR TITLE
Adjust stats grid layout for small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
           </div>
           <div
             id="stats"
-            class="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4"
+            class="mt-6 grid grid-cols-1 gap-3 min-[360px]:grid-cols-2 sm:grid-cols-4"
             aria-label="Статистика"
           ></div>
         </div>


### PR DESCRIPTION
## Summary
- update the stats grid container classes to use a single column on very small screens and expand responsively
- ensure the runtime renderer leaves the container classes untouched so width is controlled by the markup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d04f00ff448333a8f0eb4a94160ed9