### PR TITLE
Adjust countdown countdown cadence and aria-live handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,11 +260,10 @@
           </div>
           <div
             class="mt-4 inline-flex items-center gap-3 rounded-2xl border border-black/10 bg-white/70 px-4 py-2 backdrop-blur"
-            aria-live="polite"
           >
             <span class="text-sm">Старт: <span class="font-semibold">20 октября 2025</span></span>
             <span class="text-sm opacity-70"
-              >Осталось: <span class="font-medium" id="countdown">—</span></span
+              >Осталось: <span class="font-medium" id="countdown" aria-live="off">—</span></span
             >
           </div>
           <div

--- a/src/main.js
+++ b/src/main.js
@@ -1736,19 +1736,51 @@ function renderProgram() {
 }
 function initCountdown() {
   const el = document.getElementById('countdown');
+  if (!el) return;
+
+  let lastContent = '';
+  let liveMode = '';
+  let timerId = null;
+
+  function setLiveMode(nextMode) {
+    if (liveMode === nextMode) return;
+    if (nextMode) {
+      el.setAttribute('aria-live', nextMode);
+    } else {
+      el.removeAttribute('aria-live');
+    }
+    liveMode = nextMode;
+  }
+
   function tick() {
     const status = getCountdownStatus(COURSE_START, new Date());
-    if (!el) return;
+
     if (status.isStarted) {
-      el.textContent = 'курс начался';
+      setLiveMode('polite');
+      const startedMessage = 'курс начался';
+      if (lastContent !== startedMessage) {
+        el.textContent = startedMessage;
+        lastContent = startedMessage;
+      }
+      if (timerId !== null) {
+        clearInterval(timerId);
+        timerId = null;
+      }
       return;
     }
-    const diffMs = Math.max(0, COURSE_START.getTime() - Date.now());
-    const seconds = Math.floor((diffMs % 60000) / 1000);
-    el.textContent = `${status.days}д ${status.hours}ч ${status.minutes}м ${String(seconds).padStart(2, '0')}с`;
+
+    const isLastHour = status.days === 0 && status.hours === 0;
+    setLiveMode(isLastHour ? 'polite' : 'off');
+
+    const nextText = `${status.days}д ${status.hours}ч ${status.minutes}м`;
+    if (nextText !== lastContent) {
+      el.textContent = nextText;
+      lastContent = nextText;
+    }
   }
+
   tick();
-  setInterval(tick, 1000);
+  timerId = setInterval(tick, 60000);
 }
 const FEEDBACK_HIDE_DELAY = 6000;
 function buildApplicationSummary({ name, email, comment }) {


### PR DESCRIPTION
## Summary
- update the countdown widget to refresh once per minute without seconds and stop after start
- toggle the aria-live region only during the last hour or when the course starts to avoid extra announcements
- move the aria-live attribute from the banner container to the countdown span

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d04edbc5d88333bc9d55c240e76a6d