### PR TITLE
Fix team section paragraph max width class

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,7 +341,7 @@
     <div class="divider"></div>
     <section id="team" class="mx-auto max-w-6xl px-4 py-16">
       <h2 class="reveal text-3xl font-semibold tracking-tight md:text-4xl">Команда</h2>
-      <p class="reveal mt-2 max-ww-3xl text-black/60">
+      <p class="reveal mt-2 max-w-3xl text-black/60">
         РГСУ — один из ведущих центров компетенций по реверсивному инжинирингу. Среди преподавателей
         — чемпионы и эксперты WorldSkills/BRICS.
       </p>


### PR DESCRIPTION
## Summary
- correct the team section paragraph width utility class from `max-ww-3xl` to `max-w-3xl` to ensure proper layout on large screens

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d04ed95a508333a1251297c62f3485