### PR TITLE
Guard gallery manifest version access

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -357,9 +357,8 @@ const helpfulLinks = [
   },
 ];
 const GALLERY_FOLDER = 'images/gallery';
-const GALLERY_MANIFEST = `${GALLERY_FOLDER}/manifest.json?v=${encodeURIComponent(
-  import.meta.env.VITE_APP_VERSION ?? 'dev',
-)}`;
+const APP_VERSION = (import.meta.env && import.meta.env.VITE_APP_VERSION) || 'dev';
+const GALLERY_MANIFEST = `${GALLERY_FOLDER}/manifest.json?v=${encodeURIComponent(APP_VERSION)}`;
 const COURSE_START = new Date('2025-10-20T09:00:00+03:00');
 const $ = (sel, el = document) => el.querySelector(sel);
 const $$ = (sel, el = document) => Array.from(el.querySelectorAll(sel));


### PR DESCRIPTION
## Summary
- avoid dereferencing undefined import.meta.env when building the gallery manifest URL
- keep gallery manifest versioning working in bundler builds while allowing vanilla browser execution

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d074410ad4833393d461f491b89563