### PR TITLE
fix(build): copy accessibility stylesheet

### DIFF
--- a/assets/css/a11y.css
+++ b/assets/css/a11y.css
@@ -1,0 +1,42 @@
+:root {
+  --a11y-focus-color: #2563eb;
+  --a11y-focus-background: rgba(37, 99, 235, 0.12);
+  --a11y-focus-offset: 4px;
+}
+
+:where(
+    a,
+    button,
+    [role='button'],
+    input,
+    textarea,
+    select,
+    summary,
+    details[role='button']
+  ):focus-visible {
+  outline: 3px solid var(--a11y-focus-color);
+  outline-offset: var(--a11y-focus-offset);
+  box-shadow: 0 0 0 4px var(--a11y-focus-background);
+  border-radius: 0.75rem;
+}
+
+.skip-link {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  padding: 0.75rem 1rem;
+  background-color: #0f172a;
+  color: #f8fafc;
+  border-radius: 0.75rem;
+  transform: translateY(-150%);
+  transition: transform 0.2s ease;
+  z-index: 100;
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+}
+
+:where(body):focus-visible {
+  outline: none;
+}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -42,7 +42,7 @@ async function build() {
   await rm(distDir, { recursive: true, force: true });
   await mkdir(distDir, { recursive: true });
   await generateSitemap();
-  const assetsToCopy = ['index.html', 'src', 'images', 'public'];
+  const assetsToCopy = ['index.html', 'src', 'images', 'public', 'assets'];
   for (const asset of assetsToCopy) {
     await copyIfExists(asset);
   }

--- a/tests/unit/build-assets.test.js
+++ b/tests/unit/build-assets.test.js
@@ -1,0 +1,22 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { access } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '../../');
+
+beforeAll(async () => {
+  await execFileAsync('node', ['scripts/build.mjs'], { cwd: rootDir });
+});
+
+describe('build assets', () => {
+  it('copies accessibility stylesheet to dist', async () => {
+    const filePath = path.join(rootDir, 'dist/assets/css/a11y.css');
+    await expect(access(filePath)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- include the assets directory in the build copy list so a11y styles are shipped
- add standalone accessibility focus stylesheet and ensure it is available in dist
- cover the build step with a test that verifies dist/assets/css/a11y.css exists

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0840a5ebc8333ab369d8829d50f48