### PR TITLE
Copy public assets into dist root

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -26,7 +26,23 @@ async function copyIfExists(relativePath) {
   try {
     const stats = await stat(src);
     if (stats.isDirectory()) {
-      await copyDir(src, path.join(distDir, relativePath));
+      if (relativePath === 'public') {
+        const entries = await readdir(src, { withFileTypes: true });
+        await Promise.all(
+          entries.map(async (entry) => {
+            const srcPath = path.join(src, entry.name);
+            const destPath = path.join(distDir, entry.name);
+            if (entry.isDirectory()) {
+              await copyDir(srcPath, destPath);
+            } else if (entry.isFile()) {
+              await mkdir(path.dirname(destPath), { recursive: true });
+              await copyFile(srcPath, destPath);
+            }
+          }),
+        );
+      } else {
+        await copyDir(src, path.join(distDir, relativePath));
+      }
     } else if (stats.isFile()) {
       await mkdir(path.dirname(path.join(distDir, relativePath)), { recursive: true });
       await copyFile(src, path.join(distDir, relativePath));


### PR DESCRIPTION
## Summary
- update build script to copy the contents of the public directory directly into the dist root
- ensure nested directories and files from public are preserved when copied alongside other assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0840ba96c8333829833e8148d4469