### PR TITLE
Add carousel skeleton and loading fallback

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -198,6 +198,171 @@ a.skip-link:focus-visible {
   transform: none !important;
 }
 
+#carousel {
+  background: linear-gradient(160deg, rgba(248, 250, 252, 0.9), rgba(226, 232, 240, 0.9));
+  position: relative;
+}
+
+.carousel-skeleton {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  text-align: center;
+  color: #0f172a;
+  background: linear-gradient(160deg, rgba(241, 245, 249, 0.9), rgba(226, 232, 240, 0.9));
+}
+
+.carousel-skeleton__photo {
+  width: min(260px, 80%);
+  aspect-ratio: 4 / 3;
+  border-radius: 1.5rem;
+  border: 1px dashed rgba(15, 23, 42, 0.12);
+  background-image: linear-gradient(135deg, rgba(148, 163, 184, 0.2), rgba(100, 116, 139, 0.25));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  position: relative;
+  overflow: hidden;
+}
+
+.carousel-skeleton__photo::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    120deg,
+    transparent 15%,
+    rgba(255, 255, 255, 0.4) 30%,
+    transparent 45%
+  );
+  transform: translateX(-100%);
+  animation: carouselSkeletonShimmer 1.8s infinite;
+}
+
+.carousel-skeleton__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.carousel-skeleton__spinner {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  border: 2px solid rgba(15, 23, 42, 0.2);
+  border-top-color: rgba(15, 23, 42, 0.65);
+  animation: carouselSpinner 1s linear infinite;
+}
+
+.carousel-skeleton__text {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.carousel-fallback {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  gap: 1.25rem;
+  justify-items: center;
+  align-content: center;
+  padding: clamp(1.5rem, 5vw, 2.5rem);
+  text-align: center;
+  background: linear-gradient(165deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 240, 0.85));
+  color: #0f172a;
+}
+
+.carousel-fallback__icon {
+  font-size: 1.75rem;
+}
+
+.carousel-fallback__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.carousel-fallback__description {
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.68);
+  max-width: 32ch;
+}
+
+.carousel-fallback__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: rgba(15, 23, 42, 0.05);
+  color: inherit;
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.carousel-fallback__cta:hover {
+  background: rgba(15, 23, 42, 0.1);
+  transform: translateY(-1px);
+}
+
+.carousel-fallback__image {
+  width: clamp(140px, 40vw, 220px);
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  background: #f8fafc;
+}
+
+@media (min-width: 640px) {
+  .carousel-fallback {
+    grid-template-columns: 1fr auto;
+    text-align: left;
+    justify-items: start;
+  }
+
+  .carousel-fallback__icon {
+    grid-column: 1 / -1;
+  }
+
+  .carousel-fallback__image {
+    grid-row: span 3;
+  }
+}
+
+@keyframes carouselSkeletonShimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  60% {
+    transform: translateX(120%);
+  }
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+@keyframes carouselSpinner {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .brand {
   position: relative;
   display: grid;

--- a/index.html
+++ b/index.html
@@ -164,11 +164,20 @@
           <div
             class="relative aspect-square overflow-hidden rounded-3xl border border-black/10 bg-gradient-to-b from-neutral-50 to-neutral-100 p-2"
           >
-            <div
-              id="carousel"
-              class="relative h-full w-full overflow-hidden rounded-2xl select-none"
-              aria-roledescription="карусель"
-            ></div>
+          <div
+            id="carousel"
+            class="relative h-full w-full overflow-hidden rounded-2xl select-none"
+            aria-roledescription="карусель"
+            aria-busy="true"
+          >
+            <div class="carousel-skeleton" data-carousel-skeleton>
+              <div class="carousel-skeleton__photo" aria-hidden="true"></div>
+              <div class="carousel-skeleton__status" role="status">
+                <span class="carousel-skeleton__spinner" aria-hidden="true"></span>
+                <span class="carousel-skeleton__text">Загружаем галерею курса…</span>
+              </div>
+            </div>
+          </div>
             <div class="pointer-events-none absolute inset-0 rounded-3xl ring-1 ring-inset ring-black/10"></div>
           </div>
         </div>

--- a/tests/unit/carousel.test.js
+++ b/tests/unit/carousel.test.js
@@ -1,0 +1,88 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let initCarousel;
+const baseMarkup = `
+  <div id="scrollbar"></div>
+  <button id="mobileNavToggle" type="button"></button>
+  <div id="mobileNav" data-open="false" class="hidden">
+    <div data-mobile-nav-overlay class="opacity-0 pointer-events-none"></div>
+    <nav id="mobileNavPanel">
+      <div data-mobile-nav-links></div>
+      <button type="button" data-mobile-nav-close></button>
+    </nav>
+  </div>
+  <div id="stickyCta" style="opacity:1"></div>
+  <nav aria-label="Основная навигация">
+    <ul id="navLinks">
+      <li><a href="#about" data-nav="about">О курсе</a></li>
+      <li><a href="#program" data-nav="program">Программа</a></li>
+    </ul>
+  </nav>
+  <section id="top"></section>
+  <section id="about"></section>
+  <section id="program"></section>
+  <section id="team"></section>
+  <section id="apply"></section>
+  <div id="carousel" aria-roledescription="карусель" aria-busy="true">
+    <div class="carousel-skeleton" data-carousel-skeleton>
+      <div class="carousel-skeleton__photo" aria-hidden="true"></div>
+      <div class="carousel-skeleton__status" role="status">
+        <span class="carousel-skeleton__spinner" aria-hidden="true"></span>
+        <span class="carousel-skeleton__text">Загружаем галерею курса…</span>
+      </div>
+    </div>
+  </div>
+`;
+
+beforeAll(async () => {
+  globalThis.IntersectionObserver = class {
+    constructor() {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  globalThis.matchMedia = globalThis.matchMedia || ((query) => ({
+    matches: false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+  }));
+  document.body.innerHTML = baseMarkup;
+  ({ initCarousel } = await import('../../src/main.js'));
+});
+
+beforeEach(() => {
+  document.body.innerHTML = baseMarkup;
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('carousel lifecycle', () => {
+  it('replaces skeleton after successful render', () => {
+    vi.useFakeTimers();
+    initCarousel({ status: 'success', gallery: [{ id: 1, src: 'test-image.jpg', alt: 'Тест' }] });
+    vi.runAllTimers();
+    const root = document.getElementById('carousel');
+    expect(root?.querySelector('[data-carousel-skeleton]')).toBeNull();
+    const img = root?.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src') ?? '').toContain('test-image.jpg');
+    expect(root?.getAttribute('data-state')).toBe('ready');
+    vi.useRealTimers();
+  });
+
+  it('shows informative fallback on error', () => {
+    initCarousel({ status: 'error', gallery: [], error: new Error('network') });
+    const root = document.getElementById('carousel');
+    const fallback = root?.querySelector('.carousel-fallback');
+    expect(fallback).not.toBeNull();
+    expect(fallback?.textContent).toContain('Не удалось загрузить галерею');
+    const cta = fallback?.querySelector('a.carousel-fallback__cta');
+    expect(cta?.getAttribute('href')).toContain('images/gallery');
+    expect(root?.getAttribute('data-state')).toBe('error');
+  });
+});


### PR DESCRIPTION
## Summary
- add a loading skeleton layout for the hero carousel and style it for gradients, placeholder imagery, and spinner text
- harden gallery loading to surface skeleton/error states and render an actionable fallback when images are missing
- cover carousel success and error flows with a Vitest DOM test harness

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d32a01938883339c7d502a082b583d