### PR TITLE
feat(form): harden persistence and add storage tests

### DIFF
--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,126 @@
+const memoryStorage = (() => {
+  const store = new Map();
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+    removeItem(key) {
+      store.delete(key);
+    },
+    clear() {
+      store.clear();
+    },
+  };
+})();
+
+let cachedStorage = null;
+let storageChecked = false;
+
+function detectDefaultStorage(logger) {
+  if (storageChecked && cachedStorage) {
+    return cachedStorage;
+  }
+  storageChecked = true;
+  if (typeof window === 'undefined' || !window.localStorage) {
+    cachedStorage = memoryStorage;
+    return cachedStorage;
+  }
+  try {
+    const testKey = `__storage_test__${Date.now()}`;
+    window.localStorage.setItem(testKey, '1');
+    window.localStorage.removeItem(testKey);
+    cachedStorage = window.localStorage;
+  } catch (error) {
+    logger?.warn?.('Local storage unavailable, falling back to in-memory storage.', error);
+    cachedStorage = memoryStorage;
+  }
+  return cachedStorage;
+}
+
+function resolveStorage(options, logger) {
+  if (options?.storage) {
+    return options.storage;
+  }
+  return detectDefaultStorage(logger);
+}
+
+function withStorage(key, options, logger, fallbackValue, callback) {
+  const storage = resolveStorage(options, logger);
+  try {
+    return callback(storage);
+  } catch (error) {
+    if (!options?.storage && storage !== memoryStorage) {
+      logger?.warn?.('Local storage operation failed, switching to in-memory storage.', error);
+      cachedStorage = memoryStorage;
+      storageChecked = true;
+      try {
+        return callback(memoryStorage);
+      } catch (fallbackError) {
+        logger?.warn?.(`Fallback storage operation failed for key "${key}"`, fallbackError);
+        return fallbackValue;
+      }
+    }
+    logger?.warn?.(`Storage operation failed for key "${key}"`, error);
+    return fallbackValue;
+  }
+}
+
+export function readPersistentJSON(key, defaultValue = null, options = {}) {
+  const logger = options.logger ?? console;
+  const raw = withStorage(
+    key,
+    options,
+    logger,
+    null,
+    (storage) => storage.getItem?.(key) ?? null,
+  );
+  if (raw == null) {
+    return defaultValue;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    logger?.warn?.(`Failed to parse persisted value for key "${key}"`, error);
+    return defaultValue;
+  }
+}
+
+export function writePersistentJSON(key, value, options = {}) {
+  const logger = options.logger ?? console;
+  const payload = JSON.stringify(value);
+  const result = withStorage(
+    key,
+    options,
+    logger,
+    false,
+    (storage) => {
+      storage.setItem?.(key, payload);
+      return true;
+    },
+  );
+  return result === true;
+}
+
+export function removePersistentKey(key, options = {}) {
+  const logger = options.logger ?? console;
+  const result = withStorage(
+    key,
+    options,
+    logger,
+    false,
+    (storage) => {
+      storage.removeItem?.(key);
+      return true;
+    },
+  );
+  return result === true;
+}
+
+export function __resetStorageCacheForTests() {
+  cachedStorage = null;
+  storageChecked = false;
+  memoryStorage.clear();
+}

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetStorageCacheForTests,
+  readPersistentJSON,
+  writePersistentJSON,
+} from '../../src/utils/storage.js';
+
+describe('storage utils', () => {
+  beforeEach(() => {
+    __resetStorageCacheForTests();
+    const storage = globalThis.localStorage;
+    if (storage && typeof storage.clear === 'function') {
+      storage.clear();
+    }
+  });
+
+  it('returns default value when nothing is stored', () => {
+    const fallback = { foo: 'bar' };
+    const result = readPersistentJSON('missing-key', fallback);
+    expect(result).toEqual(fallback);
+  });
+
+  it('persists and reads JSON payloads via available storage', () => {
+    const key = 'course-apply';
+    const payload = { name: 'Тест', email: 'user@example.com', agree: true };
+    expect(writePersistentJSON(key, payload)).toBe(true);
+    const restored = readPersistentJSON(key, {});
+    expect(restored).toEqual(payload);
+  });
+
+  it('falls back to memory storage when localStorage throws', () => {
+    const storage = globalThis.localStorage;
+    const setSpy = vi.spyOn(storage, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+    const getSpy = vi.spyOn(storage, 'getItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+    const removeSpy = vi.spyOn(storage, 'removeItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+    __resetStorageCacheForTests();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const key = 'fallback-case';
+    const payload = { ok: true };
+
+    try {
+      expect(writePersistentJSON(key, payload)).toBe(true);
+      expect(readPersistentJSON(key, null)).toEqual(payload);
+    } finally {
+      warnSpy.mockRestore();
+      setSpy.mockRestore();
+      getSpy.mockRestore();
+      removeSpy.mockRestore();
+      __resetStorageCacheForTests();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a storage helper that falls back to in-memory persistence when localStorage is unavailable
- refactor the apply form to reuse the helper and keep state initialization safe, plus guard the scrollbar init
- cover the storage helper with unit tests for default, success and fallback scenarios

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d32d88b50c833380e31e0d20e2f446