### PR TITLE
fix(apply): close layout container

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,27 +399,28 @@
             <div id="faqList" class="mt-4 space-y-3" role="list"></div>
           </section>
         </form>
-      <div class="mt-4 space-y-2 text-xs opacity-70">
-        <p>
-          Нажимая кнопку «Отправить заявку», вы даёте
-          <span class="underline">согласие на обработку персональных данных</span> и подтверждаете
-          ознакомление с политикой конфиденциальности.
-        </p>
-        <p>
-          Индустриальный партнёр курса — <span class="font-medium">STEP_3D</span>. По всем вопросам
-          можно
-          <a class="underline" href="https://t.me/step3d_support" target="_blank" rel="noreferrer"
-            >Связаться с нами в Telegram</a
-          >.
-        </p>
-        <p>
-          По предварительной договорённости (<span class="font-medium">от 6 человек</span>) мы можем
-          согласовать и утвердить удобные для вашей команды даты старта и расписания.
-        </p>
-      </div>
-      <div class="mt-6">
-        <div class="text-sm opacity-60">Полезные ссылки</div>
-        <div id="helpfulLinks" class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3"></div>
+        <div class="mt-4 space-y-2 text-xs opacity-70">
+          <p>
+            Нажимая кнопку «Отправить заявку», вы даёте
+            <span class="underline">согласие на обработку персональных данных</span> и подтверждаете
+            ознакомление с политикой конфиденциальности.
+          </p>
+          <p>
+            Индустриальный партнёр курса — <span class="font-medium">STEP_3D</span>. По всем вопросам
+            можно
+            <a class="underline" href="https://t.me/step3d_support" target="_blank" rel="noreferrer"
+              >Связаться с нами в Telegram</a
+            >.
+          </p>
+          <p>
+            По предварительной договорённости (<span class="font-medium">от 6 человек</span>) мы можем
+            согласовать и утвердить удобные для вашей команды даты старта и расписания.
+          </p>
+        </div>
+        <div class="mt-6">
+          <div class="text-sm opacity-60">Полезные ссылки</div>
+          <div id="helpfulLinks" class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3"></div>
+        </div>
       </div>
     </section>
     <aside


### PR DESCRIPTION
## Summary
- restore the closing layout wrapper in the application section so the disclaimer and helpful links render inside the section

## Testing
- npm run lint
- npm test
- npm run build
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d335a8f9c88333afcb8baa2d119ef0