### PR TITLE
Sanitize application feedback rendering

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,10 @@ import {
   getBlocksSummary,
   getCountdownStatus,
 } from './utils/course-utils.js';
+import {
+  buildApplicationSummary,
+  createFeedbackCard,
+} from './utils/application-feedback.js';
 import { COURSE_START, COURSE_START_ISO } from './data/course.js';
 
 const courseStartLabel = formatLongDateRu(COURSE_START);
@@ -1616,25 +1620,6 @@ function initCountdown() {
   timerId = setInterval(tick, 60000);
 }
 const FEEDBACK_HIDE_DELAY = 6000;
-function buildApplicationSummary({ name, email, comment }) {
-  const trimmedName = name.trim();
-  const firstName = trimmedName ? trimmedName.split(/\s+/)[0] : 'Коллега';
-  const emailPart = email.trim();
-  const commentPart = comment.trim();
-  const details = [];
-  if (commentPart) {
-    details.push(`Мы учтём ваш запрос: «${commentPart}».`);
-  }
-  if (emailPart) {
-    details.push(`Подтверждение отправим на ${emailPart}.`);
-  }
-  return {
-    title: `${firstName}, заявка отправлена!`,
-    body:
-      details.join(' ') ||
-      'Спасибо за интерес к интенсиву. Менеджер свяжется с вами и расскажет про свободные места.',
-  };
-}
 function initForm() {
   const form = document.getElementById('applyForm');
   const submitBtn = document.getElementById('submitBtn');
@@ -1680,29 +1665,10 @@ function initForm() {
       clearTimeout(feedbackTimer);
       feedbackTimer = null;
     }
-    feedbackHost.innerHTML = `
-      <div class="feedback-card rounded-2xl border border-black/10 bg-white p-4 shadow-soft-md" data-state="hidden" role="status">
-        <div class="flex items-start gap-3">
-          <div>
-            <p class="text-sm font-semibold text-ink-950">${summary.title}</p>
-            <p class="mt-1 text-sm text-ink-800">${summary.body}</p>
-          </div>
-          <button
-            type="button"
-            class="ml-auto inline-flex h-7 w-7 flex-none items-center justify-center rounded-full border border-black/10 text-xs text-ink-700 transition hover:bg-black hover:text-white"
-            aria-label="Скрыть уведомление"
-            data-feedback-close
-          >
-            ×
-          </button>
-        </div>
-      </div>
-    `;
-    const card = feedbackHost.querySelector('.feedback-card');
-    const closeBtn = feedbackHost.querySelector('[data-feedback-close]');
-    if (closeBtn) {
-      closeBtn.addEventListener('click', hideFeedback, { once: true });
-    }
+    feedbackHost.innerHTML = '';
+    const { card, closeBtn } = createFeedbackCard(summary || {});
+    feedbackHost.append(card);
+    closeBtn?.addEventListener('click', hideFeedback, { once: true });
     window.requestAnimationFrame(() => {
       card?.setAttribute('data-state', 'visible');
     });

--- a/src/utils/application-feedback.js
+++ b/src/utils/application-feedback.js
@@ -1,0 +1,55 @@
+export function buildApplicationSummary({ name, email, comment }) {
+  const trimmedName = (name || '').trim();
+  const firstName = trimmedName ? trimmedName.split(/\s+/)[0] : 'Коллега';
+  const emailPart = (email || '').trim();
+  const commentPart = (comment || '').trim();
+  const details = [];
+  if (commentPart) {
+    details.push(`Мы учтём ваш запрос: «${commentPart}».`);
+  }
+  if (emailPart) {
+    details.push(`Подтверждение отправим на ${emailPart}.`);
+  }
+  return {
+    title: `${firstName}, заявка отправлена!`,
+    body:
+      details.join(' ') ||
+      'Спасибо за интерес к интенсиву. Менеджер свяжется с вами и расскажет про свободные места.',
+  };
+}
+
+export function createFeedbackCard(summary) {
+  const card = document.createElement('div');
+  card.className =
+    'feedback-card rounded-2xl border border-black/10 bg-white p-4 shadow-soft-md';
+  card.setAttribute('data-state', 'hidden');
+  card.setAttribute('role', 'status');
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'flex items-start gap-3';
+
+  const textContainer = document.createElement('div');
+
+  const titleEl = document.createElement('p');
+  titleEl.className = 'text-sm font-semibold text-ink-950';
+  titleEl.textContent = summary?.title ?? '';
+
+  const bodyEl = document.createElement('p');
+  bodyEl.className = 'mt-1 text-sm text-ink-800';
+  bodyEl.textContent = summary?.body ?? '';
+
+  textContainer.append(titleEl, bodyEl);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className =
+    'ml-auto inline-flex h-7 w-7 flex-none items-center justify-center rounded-full border border-black/10 text-xs text-ink-700 transition hover:bg-black hover:text-white';
+  closeBtn.setAttribute('aria-label', 'Скрыть уведомление');
+  closeBtn.setAttribute('data-feedback-close', '');
+  closeBtn.textContent = '×';
+
+  wrapper.append(textContainer, closeBtn);
+  card.append(wrapper);
+
+  return { card, closeBtn };
+}

--- a/tests/unit/application-feedback.test.js
+++ b/tests/unit/application-feedback.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildApplicationSummary,
+  createFeedbackCard,
+} from '../../src/utils/application-feedback.js';
+
+describe('application feedback', () => {
+  it('builds a personalised summary with raw user input', () => {
+    const summary = buildApplicationSummary({
+      name: '  <script>alert(1)</script>  ',
+      email: ' user@example.com ',
+      comment: ' <img src=x onerror=alert(1)> ',
+    });
+
+    expect(summary.title).toBe('<script>alert(1)</script>, заявка отправлена!');
+    expect(summary.body).toContain('Мы учтём ваш запрос: «<img src=x onerror=alert(1)>».');
+    expect(summary.body).toContain('Подтверждение отправим на user@example.com.');
+  });
+
+  it('renders feedback card with escaped user input', () => {
+    const summary = {
+      title: '<strong>Заголовок</strong>',
+      body: '<script>alert("boom")</script>',
+    };
+
+    const { card } = createFeedbackCard(summary);
+    const titleEl = card.querySelector('p');
+    const bodyEl = card.querySelectorAll('p')[1];
+
+    expect(titleEl.textContent).toBe('<strong>Заголовок</strong>');
+    expect(bodyEl.textContent).toBe('<script>alert("boom")</script>');
+    expect(card.innerHTML).not.toContain('<script>');
+    expect(card.innerHTML).not.toContain('<strong>');
+  });
+});


### PR DESCRIPTION
## Summary
- move the application summary builder into a dedicated utility and render feedback cards via DOM nodes to avoid HTML injection
- update the form feedback workflow to use the new helper when showing messages
- add unit tests that ensure script tags are displayed as text in the feedback card

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d341a1bf18833386bce1a292fdeeff