### PR TITLE
Handle missing CTA safely

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1808,12 +1808,14 @@ function initObservers() {
               a.removeAttribute('aria-current');
             }
           });
-          if (id === 'apply') {
-            cta.style.opacity = '0';
-            cta.style.pointerEvents = 'none';
-          } else {
-            cta.style.opacity = '1';
-            cta.style.pointerEvents = 'auto';
+          if (cta) {
+            if (id === 'apply') {
+              cta.style.opacity = '0';
+              cta.style.pointerEvents = 'none';
+            } else {
+              cta.style.opacity = '1';
+              cta.style.pointerEvents = 'auto';
+            }
           }
         }
       });


### PR DESCRIPTION
## Summary
- guard sticky CTA updates in initObservers to avoid null references while keeping navigation highlighting intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d341a404e0833380898d319a754885