### PR TITLE
Fix program tab initialization and add tests

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,10 @@
+const isTest = process.env.VITEST === 'true' || process.env.NODE_ENV === 'test';
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: isTest
+    ? {}
+    : {
+        tailwindcss: {},
+        autoprefixer: {},
+      },
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1309,14 +1309,23 @@ function renderStartCalendar() {
   const body = `<div class="grid grid-cols-6 bg-white/30 text-sm">${arr.map((d) => `<div class="px-3 py-3 text-center"><div class="inline-flex min-w-[3rem] items-center justify-center rounded-full border border-black/10 px-3 py-1">${formatShortDateRu(d)}</div></div>`).join('')}</div>`;
   root.innerHTML = head + body;
 }
-function renderProgram() {
+export function getInitialOpenDay(programModules = []) {
+  if (!Array.isArray(programModules)) return '';
+  const firstWithDay = programModules.find((module) => {
+    const day = module?.day;
+    return typeof day === 'string' && day.trim().length > 0;
+  });
+  return firstWithDay?.day ?? '';
+}
+function renderProgram(options = {}) {
+  const programModules = Array.isArray(options.modules) ? options.modules : modules;
   const root = $('#programRoot');
   if (!root) {
     console.warn('Контейнер программы (#programRoot) не найден. Секция расписания не будет инициализирована.');
     return;
   }
   let view = 'full';
-  let openDay = '01 (Пн)';
+  let openDay = getInitialOpenDay(programModules);
   const railTone = (t) =>
     ({
       lecture: 'from-sky-400/40',
@@ -1408,7 +1417,15 @@ function renderProgram() {
     const tabs = $('#dayTabs');
     if (!tabs) return;
     tabs.innerHTML = '';
-    modules.forEach((m, i) => {
+    if (programModules.length === 0) {
+      const placeholder = document.createElement('div');
+      placeholder.className =
+        'flex min-h-[64px] w-full items-center justify-center rounded-2xl border border-dashed border-black/10 bg-white px-4 text-sm text-ink-600';
+      placeholder.textContent = 'Расписание формируется. Подробности появятся ближе к старту.';
+      tabs.appendChild(placeholder);
+      return;
+    }
+    programModules.forEach((m, i) => {
       const isActive = openDay === m.day;
       const d = new Date(COURSE_START.getTime() + i * 86400000);
       const summary = getBlocksSummary(m.blocks);
@@ -1444,7 +1461,15 @@ function renderProgram() {
   }
   function renderDays() {
     body.innerHTML = '';
-    modules.forEach((m, i) => {
+    if (programModules.length === 0) {
+      const placeholder = document.createElement('div');
+      placeholder.className =
+        'rounded-2xl border border-dashed border-black/10 bg-white p-6 text-center text-sm text-ink-700 shadow-sm';
+      placeholder.textContent = 'Скоро появится подробное расписание по дням. Следите за обновлениями!';
+      body.appendChild(placeholder);
+      return;
+    }
+    programModules.forEach((m, i) => {
       const host = document.createElement('div');
       host.className = 'relative z-10 border-b border-black/10';
       const summary = getBlocksSummary(m.blocks);
@@ -1991,23 +2016,27 @@ function renderLead() {
   setText('leadPriceInline', lead.price);
   setText('leadPriceMobile', lead.price);
 }
-renderHeroStart();
-renderBenefits();
-renderStats();
-loadGallery()
-  .then(initCarousel)
-  .catch(() => initCarousel([]));
-renderAudience();
-renderStartCalendar();
-renderProgram();
-renderTeam();
-renderTeamShowcase();
-renderApplyLocations();
-renderFaq();
-renderHelpfulLinks();
-initCountdown();
-initForm();
-initObservers();
-initMobileNav();
-initScrollBar();
-renderLead();
+export { renderProgram };
+
+if (!globalThis.__STEP3D_SKIP_AUTO_INIT__) {
+  renderHeroStart();
+  renderBenefits();
+  renderStats();
+  loadGallery()
+    .then(initCarousel)
+    .catch(() => initCarousel([]));
+  renderAudience();
+  renderStartCalendar();
+  renderProgram();
+  renderTeam();
+  renderTeamShowcase();
+  renderApplyLocations();
+  renderFaq();
+  renderHelpfulLinks();
+  initCountdown();
+  initForm();
+  initObservers();
+  initMobileNav();
+  initScrollBar();
+  renderLead();
+}

--- a/tests/unit/program-render.test.js
+++ b/tests/unit/program-render.test.js
@@ -1,0 +1,81 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('program rendering', () => {
+  let renderProgram;
+  let getInitialOpenDay;
+  let rafSpy;
+
+  beforeAll(async () => {
+    globalThis.__STEP3D_SKIP_AUTO_INIT__ = true;
+    ({ renderProgram, getInitialOpenDay } = await import('../../src/main.js'));
+  });
+
+  afterAll(() => {
+    delete globalThis.__STEP3D_SKIP_AUTO_INIT__;
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="programRoot"></div>';
+    if (!window.requestAnimationFrame) {
+      window.requestAnimationFrame = (cb) => {
+        cb();
+        return 0;
+      };
+    }
+    rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb();
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    rafSpy?.mockRestore();
+    document.body.innerHTML = '';
+  });
+
+  it('selects the first available day for the initial state', () => {
+    expect(
+      getInitialOpenDay([
+        { day: '10 (Пн)', blocks: [] },
+        { day: '11 (Вт)', blocks: [] },
+      ]),
+    ).toBe('10 (Пн)');
+    expect(
+      getInitialOpenDay([
+        { day: '  ' },
+        { day: '11 (Вт)', blocks: [] },
+      ]),
+    ).toBe('11 (Вт)');
+    expect(getInitialOpenDay([])).toBe('');
+  });
+
+  it('renders fallbacks when program modules are empty', () => {
+    renderProgram({ modules: [] });
+
+    const tabs = document.querySelector('#dayTabs');
+    expect(tabs).toBeTruthy();
+    expect(tabs?.textContent).toContain('Расписание формируется');
+
+    const body = document.querySelector('#programDays');
+    expect(body).toBeTruthy();
+    expect(body?.textContent).toContain('Скоро появится подробное расписание');
+  });
+
+  it('expands the first module even if its title changes', () => {
+    renderProgram({
+      modules: [
+        { day: '10 (Пн — обновлено)', blocks: [] },
+        { day: '11 (Вт)', blocks: [] },
+      ],
+    });
+
+    const dayButtons = document.querySelectorAll('#programDays button[aria-expanded]');
+    expect(dayButtons.length).toBeGreaterThan(1);
+    expect(dayButtons[0].getAttribute('aria-expanded')).toBe('true');
+    expect(dayButtons[1].getAttribute('aria-expanded')).toBe('false');
+
+    const panels = document.querySelectorAll('#programDays [id^="program-day-"]');
+    expect(panels[0]?.hasAttribute('hidden')).toBe(false);
+    expect(panels[1]?.hasAttribute('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- derive the initial program tab from the provided modules and render empty-state placeholders
- export the program renderer with a test-friendly guard so it can be exercised in Vitest
- skip PostCSS plugins when running under Vitest and add unit coverage for the program schedule selection

## Testing
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68d341a2abc08333a896fd02d6a045e3