### PR TITLE
feat: allow dismissing sticky cta

### DIFF
--- a/index.html
+++ b/index.html
@@ -430,11 +430,26 @@
       aria-label="Стоимость и ссылка на запись"
     >
       <div class="layout">
-        <div class="flex items-center justify-between rounded-2xl border border-black/10 bg-white/90 px-4 py-2 shadow-lg backdrop-blur">
+        <div class="flex items-center justify-between gap-3 rounded-2xl border border-black/10 bg-white/90 px-4 py-2 shadow-lg backdrop-blur">
           <span class="text-sm"
             >Стоимость: <span class="font-semibold" id="leadPriceMobile"></span
           ></span>
-          <a href="#apply" class="rounded-xl bg-black px-3 py-1.5 text-white">Записаться</a>
+          <div class="flex items-center gap-2">
+            <a
+              href="#apply"
+              class="rounded-xl bg-black px-3 py-1.5 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/30"
+              >Записаться</a
+            >
+            <button
+              type="button"
+              id="stickyCtaDismiss"
+              class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-black/10 text-sm text-ink-500 transition hover:bg-black hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              aria-controls="stickyCta"
+            >
+              <span aria-hidden="true" class="text-base leading-none">×</span>
+              <span class="sr-only">Скрыть предложение</span>
+            </button>
+          </div>
         </div>
       </div>
     </aside>

--- a/src/main.js
+++ b/src/main.js
@@ -1799,7 +1799,7 @@ function initObservers() {
               a.removeAttribute('aria-current');
             }
           });
-          if (cta) {
+          if (cta && cta.dataset.dismissed !== 'true') {
             if (id === 'apply') {
               cta.style.opacity = '0';
               cta.style.pointerEvents = 'none';
@@ -1826,6 +1826,45 @@ function initObservers() {
     { threshold: 0.15 },
   );
   Array.from(document.querySelectorAll('.reveal')).forEach((el) => reveal.observe(el));
+}
+function initStickyCta() {
+  const cta = document.getElementById('stickyCta');
+  if (!cta) return;
+  const dismissBtn = document.getElementById('stickyCtaDismiss');
+  const storageKey = 'stickyCtaDismissed';
+  const hide = (persist) => {
+    cta.classList.add('hidden');
+    cta.setAttribute('aria-hidden', 'true');
+    cta.style.pointerEvents = 'none';
+    cta.dataset.dismissed = 'true';
+    if (persist) {
+      try {
+        localStorage.setItem(storageKey, '1');
+      } catch (error) {
+        console.warn('Не удалось сохранить состояние скрытия CTA', error);
+      }
+    }
+  };
+  const show = () => {
+    cta.classList.remove('hidden');
+    cta.setAttribute('aria-hidden', 'false');
+    cta.style.pointerEvents = 'auto';
+    cta.dataset.dismissed = 'false';
+  };
+  let dismissed = false;
+  try {
+    dismissed = localStorage.getItem(storageKey) === '1';
+  } catch (error) {
+    console.warn('Не удалось прочитать состояние скрытия CTA', error);
+  }
+  if (dismissed) {
+    hide(false);
+    return;
+  }
+  show();
+  if (dismissBtn) {
+    dismissBtn.addEventListener('click', () => hide(true));
+  }
 }
 function initScrollBar() {
   const bar = document.getElementById('scrollbar');
@@ -2003,6 +2042,7 @@ if (!globalThis.__STEP3D_SKIP_AUTO_INIT__) {
   renderHelpfulLinks();
   initCountdown();
   initForm();
+  initStickyCta();
   initObservers();
   initMobileNav();
   initScrollBar();


### PR DESCRIPTION
## Summary
- add a dismiss control with accessible labelling to the sticky CTA banner
- persist the dismissal choice in localStorage and hide the CTA when returning
- guard scroll observers from re-enabling a dismissed CTA while keeping price updates intact

## Testing
- npm run lint *(fails: tests reference browser globals `document`/`window` outside jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68d34622b7a48333a714ba60eed5c58a