### PR TITLE
Add calendar download CTA and ICS helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,30 @@
                 class="rounded-xl border border-black/10 px-5 py-2.5 text-sm font-medium transition hover:bg-black hover:text-white"
                 >Смотреть программу</a
               >
+              <button
+                type="button"
+                id="addToCalendarBtn"
+                class="inline-flex items-center gap-2 rounded-xl border border-black/10 px-5 py-2.5 text-sm font-medium transition hover:bg-black hover:text-white"
+                aria-label="Добавить в календарь: старт 20 октября 2025"
+              >
+                <span aria-hidden="true" class="h-4 w-4 text-current">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-full w-full">
+                    <rect x="3" y="5" width="18" height="16" rx="2" ry="2"></rect>
+                    <path d="M3 10h18"></path>
+                    <path d="M8 3v4"></path>
+                    <path d="M16 3v4"></path>
+                  </svg>
+                </span>
+                <span>Добавить в календарь</span>
+              </button>
             </div>
+            <p
+              id="calendarMessage"
+              class="hidden rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm text-emerald-900 shadow-soft"
+              role="status"
+              aria-live="polite"
+              tabindex="-1"
+            ></p>
             <div
               class="inline-flex flex-wrap items-center gap-3 rounded-full border border-black/10 bg-white/80 px-4 py-2 text-sm shadow-soft"
             >

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import {
   formatShortDateRu,
   getBlocksSummary,
   getCountdownStatus,
+  buildCourseCalendarIcs,
 } from './utils/course-utils.js';
 import {
   buildApplicationSummary,
@@ -405,6 +406,74 @@ function renderHeroStart() {
   }
   heroStartEl.textContent = courseStartLabel;
   heroStartEl.setAttribute('data-start', COURSE_START_ISO);
+
+  const calendarBtn = document.getElementById('addToCalendarBtn');
+  if (calendarBtn) {
+    calendarBtn.setAttribute('aria-label', `Добавить в календарь: старт ${courseStartLabel}`);
+  }
+}
+
+function initCalendarDownload() {
+  const button = document.getElementById('addToCalendarBtn');
+  const message = document.getElementById('calendarMessage');
+  if (!button || !message) {
+    if (!button) {
+      console.warn('Кнопка добавления в календарь не найдена.');
+    }
+    return;
+  }
+
+  const updateLabel = () => {
+    button.setAttribute('aria-label', `Добавить в календарь: старт ${courseStartLabel}`);
+  };
+
+  updateLabel();
+
+  const resetMessage = () => {
+    message.classList.add('hidden');
+    message.textContent = '';
+  };
+
+  resetMessage();
+
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    resetMessage();
+
+    try {
+      const pageUrl =
+        typeof window !== 'undefined' && window.location && window.location.href
+          ? window.location.href
+          : 'https://step3dlab.github.io/4I.AM.R22/';
+      const icsContent = buildCourseCalendarIcs({
+        durationHours: totalProgramHours,
+        title: 'Реверсивный инжиниринг и АТ — интенсив',
+        description:
+          'Практический курс STEP_3D × РГСУ: 3D-сканирование → реверс в CAD → 3D-печать оснастки и мастер-моделей.',
+        location: lead.venue,
+        url: pageUrl,
+      });
+      const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = 'step3d-course.ics';
+      document.body.append(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+
+      message.textContent = `Файл календаря скачан. Старт ${courseStartLabel}.`;
+    } catch (error) {
+      console.error('Не удалось сформировать файл календаря', error);
+      message.textContent = 'Не удалось подготовить файл календаря. Попробуйте ещё раз.';
+    }
+
+    message.classList.remove('hidden');
+    window.requestAnimationFrame(() => {
+      message.focus({ preventScroll: true });
+    });
+  });
 }
 function createPill(text, tone = 'neutral') {
   const tones = {
@@ -1989,6 +2058,7 @@ export { renderProgram };
 if (!globalThis.__STEP3D_SKIP_AUTO_INIT__) {
   renderHeroStart();
   renderBenefits();
+  initCalendarDownload();
   renderStats();
   loadGallery()
     .then(initCarousel)


### PR DESCRIPTION
## Summary
- add a hero CTA button with accessible confirmation messaging to download an ICS file
- create a reusable helper that generates course calendar ICS content including duration and metadata
- hook the new CTA into the helper so clicking triggers file download and screen reader feedback

## Testing
- npm run lint *(fails: tests reference browser globals in Node environment)*
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3462332b48333bbf63e00e48fa527