### PR TITLE
Handle missing scrollbar element

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1909,6 +1909,7 @@ function initStickyCta() {
 }
 function initScrollBar() {
   const bar = document.getElementById('scrollbar');
+  if (!bar) return;
   function onScroll() {
     const h = document.documentElement;
     const scrolled = h.scrollTop / (h.scrollHeight - h.clientHeight || 1);
@@ -2064,7 +2065,7 @@ function renderLead() {
   setText('leadPriceInline', lead.price);
   setText('leadPriceMobile', lead.price);
 }
-export { renderProgram };
+export { renderProgram, initScrollBar };
 
 if (!globalThis.__STEP3D_SKIP_AUTO_INIT__) {
   renderHeroStart();

--- a/tests/unit/scrollbar.test.js
+++ b/tests/unit/scrollbar.test.js
@@ -1,0 +1,28 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+describe('initScrollBar', () => {
+  let initScrollBar;
+
+  beforeAll(async () => {
+    globalThis.__STEP3D_SKIP_AUTO_INIT__ = true;
+    ({ initScrollBar } = await import('../../src/main.js'));
+  });
+
+  afterAll(() => {
+    delete globalThis.__STEP3D_SKIP_AUTO_INIT__;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('exits early if the scrollbar element is missing', () => {
+    const documentSpy = vi.spyOn(document, 'addEventListener');
+    const windowSpy = vi.spyOn(window, 'addEventListener');
+
+    expect(() => initScrollBar()).not.toThrow();
+    expect(documentSpy).not.toHaveBeenCalled();
+    expect(windowSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- prevent initScrollBar from registering listeners when the scrollbar element is absent
- export initScrollBar for testing and cover the missing-element scenario with a Vitest case

## Testing
- npm test
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3540435b483338d222b69181d5f2a