### PR TITLE
Fix clampIndex normalization and extend tests

### DIFF
--- a/src/utils/course-utils.js
+++ b/src/utils/course-utils.js
@@ -113,8 +113,8 @@ export function clampIndex(current, delta, length) {
   if (!Number.isFinite(current) || !Number.isFinite(delta) || length <= 0) {
     return 0;
   }
-  const next = (current + delta + length) % length;
-  return next;
+  const normalized = ((current + delta) % length + length) % length;
+  return normalized;
 }
 
 export function calculateProgramHours(modules = []) {

--- a/tests/unit/course-utils.test.js
+++ b/tests/unit/course-utils.test.js
@@ -64,5 +64,8 @@ describe('course utils', () => {
   it('wraps carousel index safely', () => {
     expect(clampIndex(0, -1, 3)).toBe(2);
     expect(clampIndex(2, 1, 3)).toBe(0);
+    expect(clampIndex(1, 10, 4)).toBe(3);
+    expect(clampIndex(1, -10, 4)).toBe(3);
+    expect(clampIndex(0, -13, 5)).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- ensure `clampIndex` uses full modular normalization so it never returns negative indices
- extend the unit coverage of `clampIndex` to include large positive and negative delta values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d35403440c8333a20c768747c8b24d