### PR TITLE
Preserve form button base styles during validation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1756,6 +1756,20 @@ function initForm() {
       else input.classList.remove('border-red-400');
     }
   }
+  const stateClasses = {
+    enabled: ['bg-black', 'hover:opacity-90'],
+    disabled: ['cursor-not-allowed', 'bg-black/30'],
+  };
+  const baseButtonClasses = submitBtn.className
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((cls) => !stateClasses.disabled.includes(cls));
+  function applyButtonState(isEnabled) {
+    const nextClasses = isEnabled
+      ? [...baseButtonClasses, ...stateClasses.enabled]
+      : [...baseButtonClasses, ...stateClasses.disabled];
+    submitBtn.className = nextClasses.join(' ');
+  }
   function validate(silent = false) {
     const name = form.elements.name.value.trim();
     const email = form.elements.email.value.trim();
@@ -1774,9 +1788,7 @@ function initForm() {
       if (!silent) showError('agree', 'Нужно согласие на обработку данных');
     } else if (!silent) showError('agree', '');
     submitBtn.disabled = !ok;
-    submitBtn.className =
-      'rounded-xl px-4 py-2 text-white outline-none transition focus-visible:ring-2 focus-visible:ring-black/30 ' +
-      (ok ? 'bg-black hover:opacity-90' : 'bg-black/30 cursor-not-allowed');
+    applyButtonState(ok);
     return ok;
   }
   form.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- capture the submit button's base Tailwind classes once during form initialization
- toggle only the stateful classes when validation enables or disables the submit action

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d35905318883339f3473a297b00b3c