### PR TITLE
Refine hero content and reposition gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,28 +166,37 @@
                 >
               </div>
               <div
-                class="w-full max-w-sm rounded-3xl border border-black/10 bg-white/85 p-4 shadow-soft backdrop-blur"
+                class="w-full max-w-sm rounded-3xl border border-black/5 bg-gradient-to-br from-sky-500 via-indigo-500 to-indigo-600 p-4 text-white shadow-soft"
                 role="group"
                 aria-label="До старта программы"
               >
                 <div class="flex items-center gap-3">
                   <div
-                    class="grid h-12 w-12 place-items-center rounded-2xl bg-gradient-to-br from-sky-400 to-indigo-500 text-white shadow-soft"
+                    class="grid h-12 w-12 place-items-center rounded-2xl bg-white/15 text-2xl text-white"
                     aria-hidden="true"
                   >
-                    <span class="text-xl">⏳</span>
+                    <span>⏳</span>
                   </div>
                   <div class="flex-1">
-                    <div class="text-xs font-semibold uppercase tracking-[.2em] text-ink-500">
+                    <div class="text-xs font-semibold uppercase tracking-[.25em] text-white/80">
                       До старта программы
                     </div>
-                    <div id="countdown" class="mt-1 text-2xl font-semibold text-ink-900" aria-live="off">—</div>
+                    <div class="mt-1 flex items-baseline gap-2">
+                      <span
+                        id="countdown"
+                        class="text-3xl font-semibold leading-none tracking-tight text-white"
+                        aria-live="off"
+                      >
+                        —
+                      </span>
+                      <span data-countdown-unit class="text-sm font-medium text-white/80">дней</span>
+                    </div>
                   </div>
                 </div>
-                <div class="mt-4 h-2 w-full rounded-full bg-black/5" role="presentation">
+                <div class="mt-4 h-2 w-full rounded-full bg-white/25" role="presentation">
                   <div
                     id="countdownBar"
-                    class="h-2 rounded-full bg-gradient-to-r from-sky-400 to-indigo-500 transition-all duration-500"
+                    class="h-2 rounded-full bg-white transition-all duration-500"
                     role="progressbar"
                     aria-valuemin="0"
                     aria-valuemax="100"
@@ -209,6 +218,73 @@
             ></div>
             <div class="pointer-events-none absolute inset-0 rounded-3xl ring-1 ring-inset ring-black/10"></div>
           </div>
+        </div>
+      </div>
+    </section>
+    <div class="section-divider" aria-hidden="true"></div>
+    <section id="gallery" class="section-gap" aria-labelledby="section-gallery-heading">
+      <div class="layout">
+        <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+          <div class="max-w-2xl">
+            <h2 id="section-gallery-heading" class="reveal section-heading">Фотогалерея</h2>
+            <p class="reveal section-subheading">
+              Атмосфера практических занятий: оборудование, команда и результаты слушателей на площадках STEP_3D и РГСУ.
+            </p>
+          </div>
+          <div class="flex gap-2 self-start md:self-end">
+            <button
+              type="button"
+              aria-label="Предыдущий слайд"
+              data-showcase-prev
+              aria-controls="teamShowcaseFigure"
+              class="grid h-12 w-12 place-items-center rounded-full border border-black/10 bg-white/90 text-ink-900 shadow-soft transition hover:bg-black hover:text-white focus-visible:ring-2 focus-visible:ring-black/20"
+            >
+              ‹
+            </button>
+            <button
+              type="button"
+              aria-label="Следующий слайд"
+              data-showcase-next
+              aria-controls="teamShowcaseFigure"
+              class="grid h-12 w-12 place-items-center rounded-full border border-black/10 bg-white/90 text-ink-900 shadow-soft transition hover:bg-black hover:text-white focus-visible:ring-2 focus-visible:ring-black/20"
+            >
+              ›
+            </button>
+          </div>
+        </div>
+        <div class="mt-8 flex flex-col gap-4">
+          <figure
+            id="teamShowcaseFigure"
+            class="group relative overflow-hidden rounded-3xl border border-black/10 bg-white/90 p-1 shadow-soft"
+            role="group"
+            aria-roledescription="галерея"
+            tabindex="0"
+          >
+            <div class="relative overflow-hidden rounded-[26px] bg-neutral-100">
+              <picture data-showcase-picture class="block h-full w-full">
+                <img
+                  data-showcase-img
+                  alt=""
+                  class="h-full w-full rounded-[26px] object-cover transition duration-300 group-focus-visible:scale-[1.01] group-hover:scale-[1.01]"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
+              <span
+                data-showcase-tag
+                class="absolute left-5 top-5 hidden items-center rounded-full bg-black/75 px-3 py-1 text-xs font-medium text-white shadow-sm"
+              ></span>
+              <span
+                data-showcase-counter
+                class="absolute right-5 top-5 inline-flex items-center rounded-full bg-black/75 px-3 py-1 text-xs font-medium text-white shadow-sm"
+              ></span>
+            </div>
+            <figcaption class="mt-3 rounded-2xl border border-black/5 bg-white/90 px-5 py-4">
+              <div class="text-sm font-semibold text-ink-950" data-showcase-title></div>
+              <p class="mt-1 text-sm text-ink-700" data-showcase-caption></p>
+            </figcaption>
+          </figure>
+          <p id="teamShowcaseStatus" class="text-xs text-ink-600" aria-live="polite"></p>
         </div>
       </div>
     </section>
@@ -280,69 +356,6 @@
         </p>
         <div id="teamCards" class="mt-8 grid gap-4 md:grid-cols-3" aria-label="Команда курса"></div>
         <div id="teamDetail" class="mt-8"></div>
-      </div>
-    </section>
-    <section id="team-showcase" class="section-gap pt-0" aria-labelledby="section-showcase-heading">
-      <div class="layout">
-        <div class="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h3 id="section-showcase-heading" class="text-2xl font-semibold tracking-tight md:text-3xl">Фотогалерея</h3>
-          </div>
-          <div class="flex gap-2">
-            <button
-              type="button"
-              aria-label="Предыдущий слайд"
-              data-showcase-prev
-              aria-controls="teamShowcaseFigure"
-              class="grid h-10 w-10 place-items-center rounded-full border border-black/10 bg-white text-ink-950 shadow-sm transition hover:bg-black hover:text-white focus-visible:ring-2 focus-visible:ring-black/20"
-            >
-              ‹
-            </button>
-            <button
-              type="button"
-              aria-label="Следующий слайд"
-              data-showcase-next
-              aria-controls="teamShowcaseFigure"
-              class="grid h-10 w-10 place-items-center rounded-full border border-black/10 bg-white text-ink-950 shadow-sm transition hover:bg-black hover:text-white focus-visible:ring-2 focus-visible:ring-black/20"
-            >
-              ›
-            </button>
-          </div>
-        </div>
-        <div class="mt-6 flex flex-col gap-3">
-          <figure
-            id="teamShowcaseFigure"
-            class="group relative overflow-hidden rounded-3xl border border-black/10 bg-white shadow-soft"
-            role="group"
-            aria-roledescription="галерея"
-            tabindex="0"
-          >
-            <div class="relative aspect-[4/3] overflow-hidden">
-              <picture data-showcase-picture class="block h-full w-full">
-                <img
-                  data-showcase-img
-                  alt=""
-                  class="h-full w-full object-cover transition duration-300 group-focus-visible:scale-[1.01] group-hover:scale-[1.01]"
-                  loading="lazy"
-                  decoding="async"
-                />
-              </picture>
-              <span
-                data-showcase-tag
-                class="absolute left-4 top-4 hidden items-center rounded-full bg-black/75 px-3 py-1 text-xs font-medium text-white shadow-sm"
-              ></span>
-              <span
-                data-showcase-counter
-                class="absolute right-4 top-4 inline-flex items-center rounded-full bg-black/75 px-3 py-1 text-xs font-medium text-white shadow-sm"
-              ></span>
-            </div>
-            <figcaption class="border-t border-black/10 bg-white/95 px-5 py-4">
-              <div class="text-sm font-semibold text-ink-950" data-showcase-title></div>
-              <p class="mt-1 text-sm text-ink-700" data-showcase-caption></p>
-            </figcaption>
-          </figure>
-          <p id="teamShowcaseStatus" class="text-xs text-ink-600" aria-live="polite"></p>
-        </div>
       </div>
     </section>
     <div class="section-divider" aria-hidden="true"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,6 @@
 import {
   calculateProgramHours,
   clampIndex,
-  formatDaysLabel,
   formatLongDateRu,
   formatShortDateRu,
   getBlocksSummary,
@@ -552,31 +551,40 @@ function renderIcon(name) {
 function renderStats() {
   const root = $('#stats');
   if (!root) return;
-  const steps = COURSE_STEPS;
   root.className = 'hero-highlight';
+  const highlights = [
+    { label: 'Код программы', value: course.code },
+    {
+      label: 'Длительность',
+      value: Number.isFinite(course.durationHours)
+        ? `${course.durationHours} ак. ч.`
+        : course.durationHours || '',
+    },
+    { label: 'График', value: course.schedule },
+    { label: 'Стоимость', value: course.price },
+  ].filter((item) => Boolean(item.value));
+  const highlightRows = highlights
+    .map(
+      (item) => `
+        <div class="flex items-baseline justify-between gap-3 rounded-2xl bg-white/75 px-3 py-2 shadow-sm">
+          <dt class="text-[11px] font-semibold uppercase tracking-[.2em] text-ink-500">${item.label}</dt>
+          <dd class="text-sm font-semibold leading-snug text-ink-900">${item.value}</dd>
+        </div>
+      `,
+    )
+    .join('');
+  const highlightContent = highlightRows
+    ? `<dl class="mt-4 space-y-2">${highlightRows}</dl>`
+    : course.summary
+    ? `<p class="mt-4 text-sm leading-relaxed text-ink-700">${course.summary}</p>`
+    : '';
   root.innerHTML = `
     <article class="rounded-3xl border border-black/10 bg-white/85 p-5 shadow-soft backdrop-blur-sm" role="group" aria-labelledby="courseHighlightTitle">
-      <div class="text-xs font-semibold uppercase tracking-[.32em] text-ink-500">Практикум</div>
+      <div class="text-[11px] font-semibold uppercase tracking-[.3em] text-ink-500">О программе</div>
       <h3 id="courseHighlightTitle" class="mt-3 text-2xl font-semibold tracking-tight text-ink-950">
-        Практический интенсив на базе РГСУ
+        Ключевые факты о программе
       </h3>
-      <p class="mt-2 text-sm leading-relaxed text-ink-700">
-        3D-сканирование → реверс в CAD → печать оснастки и мастер-моделей. От кейсов к результату.
-      </p>
-      <div class="mt-4 flex flex-wrap items-center gap-2">
-        ${steps
-          .map(
-            (step) => `
-              <span class="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/80 px-3 py-1 text-xs font-medium text-ink-800">
-                <span class="grid h-7 w-7 place-items-center rounded-full bg-gradient-to-br from-sky-400/80 to-indigo-500/80 text-white shadow-sm" aria-hidden="true">
-                  ${renderIcon(step.icon)}
-                </span>
-                ${step.title}
-              </span>
-            `,
-          )
-          .join('')}
-      </div>
+      ${highlightContent}
     </article>
   `;
 }
@@ -600,9 +608,9 @@ function renderHeroAnimation() {
           ${stepsMarkup}
         </div>
         <div class="hero-animation__caption">
-          <span class="hero-animation__caption-title">Практический интенсив</span>
+          <span class="hero-animation__caption-title">Ключевые блоки курса</span>
           <p id="heroAnimationCaption" class="hero-animation__caption-text">
-            3D-сканирование → реверс в CAD → печать оснастки и мастер-моделей. От кейсов к результату.
+            От первого скана до готовой оснастки — практическая отработка каждого этапа.
           </p>
         </div>
       </div>
@@ -1577,9 +1585,11 @@ function initCountdown() {
 
   el.setAttribute('data-start', COURSE_START_ISO);
 
+  const unitEl = el.parentElement?.querySelector('[data-countdown-unit]') ?? null;
   const progressBar = document.getElementById('countdownBar');
 
-  let lastContent = '';
+  let lastValue = '';
+  let lastUnit = '';
   let liveMode = '';
   let timerId = null;
 
@@ -1593,16 +1603,36 @@ function initCountdown() {
     liveMode = nextMode;
   }
 
+  function updateDisplay(value, unit = '') {
+    if (lastValue !== value) {
+      el.textContent = value;
+      lastValue = value;
+    }
+    if (unitEl) {
+      const normalizedUnit = unit.trim();
+      if (lastUnit !== normalizedUnit) {
+        unitEl.textContent = normalizedUnit;
+        unitEl.classList.toggle('hidden', normalizedUnit.length === 0);
+        lastUnit = normalizedUnit;
+      }
+    }
+  }
+
+  function getDaysSuffix(value) {
+    const abs = Math.abs(value) % 100;
+    const lastDigit = abs % 10;
+    if (abs > 10 && abs < 20) return 'дней';
+    if (lastDigit === 1) return 'день';
+    if (lastDigit >= 2 && lastDigit <= 4) return 'дня';
+    return 'дней';
+  }
+
   function tick() {
     const status = getCountdownStatus(COURSE_START, new Date());
 
     if (status.isStarted) {
       setLiveMode('polite');
-      const startedMessage = 'курс начался';
-      if (lastContent !== startedMessage) {
-        el.textContent = startedMessage;
-        lastContent = startedMessage;
-      }
+      updateDisplay('курс начался', '');
       if (progressBar) {
         progressBar.style.width = '100%';
         progressBar.setAttribute('aria-valuenow', '100');
@@ -1618,11 +1648,9 @@ function initCountdown() {
     const isLastHour = status.days === 0 && status.hours === 0;
     setLiveMode(isLastHour ? 'polite' : 'off');
 
-    const nextText = status.days <= 0 ? '0 дней' : formatDaysLabel(status.days);
-    if (nextText !== lastContent) {
-      el.textContent = nextText;
-      lastContent = nextText;
-    }
+    const nextValue = Math.max(status.days, 0);
+    const nextUnit = getDaysSuffix(nextValue);
+    updateDisplay(String(nextValue), nextUnit);
 
     if (progressBar) {
       const normalizedDays = Math.min(Math.max(status.days, 0), COUNTDOWN_VISUALIZATION_RANGE_DAYS);


### PR DESCRIPTION
## Summary
- restyled the hero highlight card to show key programme facts and refreshed the carousel caption copy
- redesigned the countdown widget to match the site's gradient style and split the value/unit output
- moved and reworked the photo gallery section ahead of "Для кого" with updated controls and framing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d36cd6590883338584aabee07a0991