### PR TITLE
feat(ui): unify primary sign-up cta

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,14 +79,19 @@
                 <a href="#team" class="opacity-70 transition hover:opacity-100" data-nav="team">Команда</a>
               </li>
               <li>
-                <a href="#apply" class="opacity-70 transition hover:opacity-100" data-nav="apply">Запись</a>
+                <a
+                  href="#apply"
+                  class="opacity-70 transition hover:opacity-100"
+                  data-nav="apply"
+                  >Записаться</a
+                >
               </li>
             </ul>
           </nav>
           <a
             href="#apply"
-            class="rounded-xl border border-black/10 px-3 py-1.5 text-sm transition hover:bg-black hover:text-white"
-            >Поступить</a
+            class="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-black/10 px-4 py-2 text-sm font-medium transition hover:bg-black hover:text-white"
+            >Записаться</a
           >
         </div>
       </div>
@@ -146,8 +151,8 @@
             <div class="flex flex-wrap items-center gap-4">
               <a
                 href="#apply"
-                class="rounded-xl bg-black px-5 py-2.5 text-sm font-medium text-white transition hover:opacity-90"
-                >Подать заявку</a
+                class="inline-flex min-h-[48px] items-center justify-center rounded-xl bg-black px-6 py-2.5 text-base font-semibold text-white transition hover:opacity-90"
+                >Записаться</a
               >
               <a
                 href="#program"
@@ -356,7 +361,7 @@
     </section>
     <section id="apply" class="page-section section-gap" aria-labelledby="section-apply-heading">
       <div class="layout">
-        <h2 id="section-apply-heading" class="reveal section-heading">Поступить на курс</h2>
+        <h2 id="section-apply-heading" class="reveal section-heading">Записаться на курс</h2>
         <p class="reveal section-subheading">
           Оставьте заявку — менеджер свяжется с вами и уточнит детали (наличие мест, график, документы).
         </p>

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -4,12 +4,12 @@ test.describe('Landing page smoke', () => {
   test('loads hero and key CTA', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /реверсивный инжиниринг/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Подать заявку' }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Записаться' }).first()).toBeVisible();
   });
 
   test('navigates via primary menu', async ({ page }) => {
     await page.goto('/');
-    await page.getByRole('link', { name: 'Программа' }).click();
+    await page.getByRole('link', { name: 'Программа', exact: true }).click();
     await expect(page).toHaveURL(/#program/);
   });
 


### PR DESCRIPTION
## Summary
- rename all primary call-to-action labels in the navigation, hero button, and apply section to use “Записаться” consistently
- enlarge the hero and header sign-up buttons to meet the 44×44 px tap target guidance for mobile usability
- update smoke e2e tests to reflect the new CTA copy and resolve the strict-mode selector ambiguity in the navigation test

## Testing
- npm run lint
- npm test
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d3788e0f288333ab37e1067a2c4a30