### PR TITLE
feat: refresh course landing content

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ dist
 node_modules
 playwright-report
 lhci_reports
+assets/css/tailwind.css

--- a/app.js
+++ b/app.js
@@ -3,7 +3,9 @@ const navLinks = document.querySelectorAll('#navLinks a');
 const sections = Array.from(document.querySelectorAll('main section[id]'));
 
 if (navLinks.length && sections.length) {
-  const navMap = new Map(sections.map((section) => [section.id, document.querySelector(`a[href="#${section.id}"]`)]));
+  const navMap = new Map(
+    sections.map((section) => [section.id, document.querySelector(`a[href="#${section.id}"]`)]),
+  );
   const observer = new IntersectionObserver(
     (entries) => {
       entries.forEach((entry) => {
@@ -15,7 +17,7 @@ if (navLinks.length && sections.length) {
         }
       });
     },
-    { rootMargin: '-30% 0px -50% 0px', threshold: [0.5] }
+    { rootMargin: '-30% 0px -50% 0px', threshold: [0.5] },
   );
   sections.forEach((section) => observer.observe(section));
 }
@@ -112,13 +114,17 @@ if (carousel) {
       if (event.key === 'ArrowRight') {
         event.preventDefault();
         goToSlide(currentIndex + 1);
-        const dots = dotsContainer ? Array.from(dotsContainer.querySelectorAll('.carousel__dot')) : [];
+        const dots = dotsContainer
+          ? Array.from(dotsContainer.querySelectorAll('.carousel__dot'))
+          : [];
         dots[currentIndex]?.focus();
       }
       if (event.key === 'ArrowLeft') {
         event.preventDefault();
         goToSlide(currentIndex - 1);
-        const dots = dotsContainer ? Array.from(dotsContainer.querySelectorAll('.carousel__dot')) : [];
+        const dots = dotsContainer
+          ? Array.from(dotsContainer.querySelectorAll('.carousel__dot'))
+          : [];
         dots[currentIndex]?.focus();
       }
     });
@@ -201,9 +207,13 @@ if (form) {
   const submitButton = form.querySelector('button[type="submit"]');
   const consent = form.querySelector('#consent');
   const successMessage = form.querySelector('.form__success');
-  const requiredFields = Array.from(form.querySelectorAll('input[required][type!="checkbox"], textarea[required]'));
+  const requiredFields = Array.from(
+    form.querySelectorAll('input[required][type!="checkbox"], textarea[required]'),
+  );
   const errorMap = new Map(
-    requiredFields.map((field) => [field, document.getElementById(`${field.id}-error`)]).filter(([, node]) => node)
+    requiredFields
+      .map((field) => [field, document.getElementById(`${field.id}-error`)])
+      .filter(([, node]) => node),
   );
 
   const hideSuccessMessage = () => {
@@ -301,7 +311,8 @@ if (accordionButtons.length) {
       }
       if (event.key === 'ArrowUp') {
         event.preventDefault();
-        const prev = accordionButtons[currentIndex - 1] || accordionButtons[accordionButtons.length - 1];
+        const prev =
+          accordionButtons[currentIndex - 1] || accordionButtons[accordionButtons.length - 1];
         prev.focus();
       }
       if (event.key === 'Home') {

--- a/assets/css/a11y.css
+++ b/assets/css/a11y.css
@@ -5,15 +5,15 @@
 }
 
 :where(
-    a,
-    button,
-    [role='button'],
-    input,
-    textarea,
-    select,
-    summary,
-    details[role='button']
-  ):focus-visible {
+  a,
+  button,
+  [role='button'],
+  input,
+  textarea,
+  select,
+  summary,
+  details[role='button']
+):focus-visible {
   outline: 3px solid var(--a11y-focus-color);
   outline-offset: var(--a11y-focus-offset);
   box-shadow: 0 0 0 4px var(--a11y-focus-background);

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -148,7 +148,10 @@ a.skip-link:focus-visible {
   border: 1px solid rgba(15, 23, 42, 0.08);
   background: rgba(255, 255, 255, 0.7);
   text-decoration: none;
-  transition: border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .eyebrow:hover {
@@ -179,7 +182,9 @@ a.skip-link:focus-visible {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(237, 242, 255, 0.9));
   box-shadow: var(--shadow-soft);
   text-align: center;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
 }
 
 .stat-card::before {
@@ -269,7 +274,12 @@ a.skip-link:focus-visible {
   right: 12%;
   height: 2px;
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(56, 189, 248, 0.25), rgba(99, 102, 241, 0.5), rgba(56, 189, 248, 0.25));
+  background: linear-gradient(
+    90deg,
+    rgba(56, 189, 248, 0.25),
+    rgba(99, 102, 241, 0.5),
+    rgba(56, 189, 248, 0.25)
+  );
   transform: translateY(-50%);
   opacity: 0.8;
 }
@@ -320,7 +330,9 @@ a.skip-link:focus-visible {
   background: linear-gradient(135deg, rgba(56, 189, 248, 0.22), rgba(79, 70, 229, 0.28));
   opacity: 0;
   transform: scale(0.9);
-  transition: opacity 0.3s ease, transform 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
   animation: heroStepGlow 9s infinite ease-in-out;
   animation-delay: calc(var(--step-index, 0) * 3s);
 }
@@ -396,7 +408,13 @@ a.skip-link:focus-visible {
   position: absolute;
   inset: 16%;
   border-radius: 18px;
-  background: repeating-linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(79, 70, 229, 0.08) 6px, transparent 6px, transparent 12px);
+  background: repeating-linear-gradient(
+    135deg,
+    rgba(79, 70, 229, 0.08),
+    rgba(79, 70, 229, 0.08) 6px,
+    transparent 6px,
+    transparent 12px
+  );
   opacity: 0.7;
 }
 
@@ -448,7 +466,12 @@ a.skip-link:focus-visible {
 .team-modal__divider {
   height: 1px;
   width: 100%;
-  background: linear-gradient(90deg, rgba(15, 23, 42, 0), rgba(99, 102, 241, 0.22), rgba(15, 23, 42, 0));
+  background: linear-gradient(
+    90deg,
+    rgba(15, 23, 42, 0),
+    rgba(99, 102, 241, 0.22),
+    rgba(15, 23, 42, 0)
+  );
 }
 
 @keyframes heroRunner {
@@ -556,7 +579,9 @@ a.skip-link:focus-visible {
 .reveal {
   opacity: 0;
   transform: translateY(8px);
-  transition: opacity 0.45s ease, transform 0.45s ease;
+  transition:
+    opacity 0.45s ease,
+    transform 0.45s ease;
 }
 
 .revealed {
@@ -596,7 +621,10 @@ a.skip-link:focus-visible {
 .dot {
   height: 6px;
   border-radius: 999px;
-  transition: width 0.25s ease, background-color 0.25s ease, opacity 0.25s ease;
+  transition:
+    width 0.25s ease,
+    background-color 0.25s ease,
+    opacity 0.25s ease;
 }
 
 .hover-shimmer:hover::after {
@@ -625,7 +653,9 @@ a.skip-link:focus-visible {
 .feedback-card {
   opacity: 0;
   transform: translateY(8px);
-  transition: opacity 0.3s ease, transform 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
 }
 
 .feedback-card[data-state='visible'] {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,10 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ru_RU" />
-    <meta property="og:image" content="https://step3dlab.github.io/4I.AM.R22/images/gallery/printing.webp" />
+    <meta
+      property="og:image"
+      content="https://step3dlab.github.io/4I.AM.R22/images/gallery/printing.webp"
+    />
     <meta property="og:image:alt" content="Алексей Рекут контролирует 3D-печать детали" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Реверсивный инжиниринг и АТ — интенсив" />
@@ -28,7 +31,10 @@
       name="twitter:description"
       content="Практический образовательный интенсив на базе РГСУ: 3D-сканирование, реверсивный инжиниринг в CAD, 3D-печать."
     />
-    <meta name="twitter:image" content="https://step3dlab.github.io/4I.AM.R22/images/gallery/printing.webp" />
+    <meta
+      name="twitter:image"
+      content="https://step3dlab.github.io/4I.AM.R22/images/gallery/printing.webp"
+    />
     <!-- STEP_3D: Inline critical styles for header and hero -->
     <style>
       :root {
@@ -52,7 +58,16 @@
       }
       body {
         margin: 0;
-        font-family: ui-sans-serif, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
+        font-family:
+          ui-sans-serif,
+          -apple-system,
+          'Segoe UI',
+          Roboto,
+          'Helvetica Neue',
+          Arial,
+          'Noto Sans',
+          'Liberation Sans',
+          sans-serif;
         background: var(--bg);
         color: var(--ink);
       }
@@ -190,8 +205,12 @@
     <noscript>
       <link rel="stylesheet" href="styles.css" />
     </noscript>
+    <link rel="stylesheet" href="assets/css/tailwind.css" />
   </head>
   <body>
+    <div class="scrollbar" aria-hidden="true">
+      <span id="scrollbar"></span>
+    </div>
     <a class="skip-link" href="#mainContent">Перейти к содержимому</a>
     <header class="site-header" role="banner">
       <div class="layout site-header__inner">
@@ -214,39 +233,86 @@
         <div class="layout">
           <div class="hero__grid">
             <div class="hero__content">
-              <p class="eyebrow" data-course-tagline>Программа повышения квалификации РГСУ × STEP_3D</p>
-              <h1 id="section-hero" class="hero__title">Реверсивный инжиниринг и аддитивное производство</h1>
+              <p class="eyebrow" data-course-tagline>
+                Программа повышения квалификации РГСУ × STEP_3D
+              </p>
+              <h1 id="section-hero" class="hero__title">
+                Реверсивный инжиниринг и аддитивное производство
+              </h1>
               <p class="hero__lead" data-course-summary>
-                Интенсив на 72 часа: сканирование, обработка облаков точек, моделирование и 3D-печать с наставниками
-                производства.
+                Практический образовательный интенсив на базе РГСУ: 3D-сканирование, реверсивный
+                инжиниринг в CAD, 3D-печать.
               </p>
               <div class="hero__chips" role="group" aria-label="Формат участия">
                 <button type="button" class="chip" data-feature aria-pressed="false">
-                  <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                    <path d="M12 2.5 3 7v2l9 4.5 9-4.5V7l-9-4.5Zm0 9.2L3 7v10l9 4.5 9-4.5V7l-9 4.7Z" fill="currentColor" />
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <path
+                      d="M12 2.5 3 7v2l9 4.5 9-4.5V7l-9-4.5Zm0 9.2L3 7v10l9 4.5 9-4.5V7l-9 4.7Z"
+                      fill="currentColor"
+                    />
                   </svg>
                   Очные мастер-классы
                 </button>
                 <button type="button" class="chip" data-feature aria-pressed="false">
-                  <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
                     <path d="M5 5h14v2H5V5Zm0 6h14v2H5v-2Zm0 6h9v2H5v-2Z" fill="currentColor" />
                   </svg>
                   Учебные кейсы от партнёров
                 </button>
                 <button type="button" class="chip" data-feature aria-pressed="false">
-                  <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                    <path d="M12 2a5 5 0 0 1 5 5v3.09a6 6 0 1 1-10 0V7a5 5 0 0 1 5-5Zm0 20a3 3 0 0 0 3-3H9a3 3 0 0 0 3 3Z" fill="currentColor" />
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <path
+                      d="M12 2a5 5 0 0 1 5 5v3.09a6 6 0 1 1-10 0V7a5 5 0 0 1 5-5Zm0 20a3 3 0 0 0 3-3H9a3 3 0 0 0 3 3Z"
+                      fill="currentColor"
+                    />
                   </svg>
                   Наставники из индустрии
                 </button>
               </div>
               <div class="hero__countdown" aria-live="polite">
-                <div class="countdown" data-countdown>
-                  <span><span class="countdown__digit" data-days>00</span><span class="countdown__label">дней</span></span>
-                  <span><span class="countdown__digit" data-hours>00</span><span class="countdown__label">часов</span></span>
-                  <span><span class="countdown__digit" data-minutes>00</span><span class="countdown__label">минут</span></span>
+                <div class="countdown" role="group" aria-label="Отсчёт до старта">
+                  <span
+                    class="countdown__value"
+                    id="countdown"
+                    data-start="2025-10-20T09:00:00+03:00"
+                    >00</span
+                  >
+                  <span class="countdown__unit" data-countdown-unit>дней</span>
                 </div>
-                <p class="hero__meta">Старт 15 апреля · Москва, технопарк РГСУ</p>
+                <div
+                  class="countdown__bar"
+                  id="countdownBar"
+                  role="progressbar"
+                  aria-label="Прогресс до старта курса"
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                  aria-valuenow="0"
+                ></div>
+                <p class="hero__meta">
+                  Старт
+                  <time id="heroStartDate" data-start="2025-10-20T09:00:00+03:00"
+                    >20 октября 2025</time
+                  >
+                  · Москва, ул. Беговая, д. 12
+                </p>
               </div>
               <div class="hero__actions">
                 <a class="btn-primary" href="#apply">Записаться</a>
@@ -277,8 +343,50 @@
                   decoding="async"
                 />
               </picture>
-              <figcaption class="hero__figure-caption">Практика на промышленных FDM-принтерах</figcaption>
+              <figcaption class="hero__figure-caption">
+                Практика на промышленных FDM-принтерах
+              </figcaption>
             </figure>
+          </div>
+        </div>
+      </section>
+      <section class="section lead" aria-labelledby="section-lead">
+        <div class="layout lead__grid">
+          <div class="lead__card">
+            <p class="eyebrow">Формат обучения</p>
+            <h2 id="section-lead">Все ключевые параметры программы</h2>
+            <dl class="lead__list">
+              <div class="lead__item">
+                <dt>Длительность</dt>
+                <dd id="leadDuration">48 часов · 1 неделя, пн-сб 09:00—18:00</dd>
+              </div>
+              <div class="lead__item">
+                <dt>Старт</dt>
+                <dd id="leadStart" data-start="2025-10-20T09:00:00+03:00">
+                  Старт: 20 октября 2025
+                </dd>
+              </div>
+              <div class="lead__item">
+                <dt>Стоимость</dt>
+                <dd id="leadPrice">68 000 ₽</dd>
+              </div>
+              <div class="lead__item">
+                <dt>Группа</dt>
+                <dd id="leadSeats">6–12 человек в группе</dd>
+              </div>
+            </dl>
+            <div class="lead__cta">
+              <span class="lead__price lead__price--inline" id="leadPriceInline">68 000 ₽</span>
+              <a class="btn-primary" href="#apply">Забронировать место</a>
+              <span class="lead__price lead__price--mobile" id="leadPriceMobile">68 000 ₽</span>
+            </div>
+          </div>
+          <div class="lead__aside">
+            <section aria-labelledby="section-benefits" class="lead__benefits">
+              <h3 id="section-benefits">Практические результаты</h3>
+              <div id="benefits" class="lead__benefits-list"></div>
+            </section>
+            <section aria-labelledby="section-stats" class="lead__stats" id="stats"></section>
           </div>
         </div>
       </section>
@@ -292,15 +400,24 @@
           <div class="feature-grid" role="list">
             <article class="feature-card" role="listitem">
               <h3>Эксперты STEP_3D</h3>
-              <p>Работайте с инженерами, которые внедряют аддитивные технологии на производстве и делятся кейсами.</p>
+              <p>
+                Работайте с инженерами, которые внедряют аддитивные технологии на производстве и
+                делятся кейсами.
+              </p>
             </article>
             <article class="feature-card" role="listitem">
               <h3>Готовый проект</h3>
-              <p>Участники формируют собственный кейс: от сканирования деталей до подготовки модели к печати.</p>
+              <p>
+                Участники формируют собственный кейс: от сканирования деталей до подготовки модели к
+                печати.
+              </p>
             </article>
             <article class="feature-card" role="listitem">
               <h3>Сертификат РГСУ</h3>
-              <p>По итогам программы выдаётся удостоверение о повышении квалификации установленного образца.</p>
+              <p>
+                По итогам программы выдаётся удостоверение о повышении квалификации установленного
+                образца.
+              </p>
             </article>
           </div>
         </div>
@@ -314,7 +431,9 @@
           </div>
           <section aria-label="Фотогалерея">
             <div class="carousel" role="region" aria-roledescription="carousel">
-              <button type="button" class="carousel__control prev" aria-label="Предыдущее фото">‹</button>
+              <button type="button" class="carousel__control prev" aria-label="Предыдущее фото">
+                ‹
+              </button>
               <ul class="carousel__track" aria-live="polite">
                 <li class="carousel__slide" id="slide-1" role="tabpanel" aria-labelledby="dot-1">
                   <figure>
@@ -398,7 +517,9 @@
                   </figure>
                 </li>
               </ul>
-              <button type="button" class="carousel__control next" aria-label="Следующее фото">›</button>
+              <button type="button" class="carousel__control next" aria-label="Следующее фото">
+                ›
+              </button>
               <div class="carousel__dots" role="tablist" aria-label="Выбор слайда"></div>
             </div>
           </section>
@@ -412,60 +533,89 @@
             <h2 id="section-program">Программа интенсива</h2>
           </div>
           <div class="segmented" role="group" aria-label="Режим отображения расписания">
-            <button type="button" class="segmented__btn is-active" data-view="compact" aria-pressed="true">Компактный</button>
-            <button type="button" class="segmented__btn" data-view="detailed" aria-pressed="false">Подробный</button>
+            <button
+              type="button"
+              class="segmented__btn is-active"
+              data-view="compact"
+              aria-pressed="true"
+            >
+              Компактный
+            </button>
+            <button type="button" class="segmented__btn" data-view="detailed" aria-pressed="false">
+              Подробный
+            </button>
           </div>
           <div class="schedule" data-view="compact">
             <article class="schedule__item" data-type="lecture">
               <header class="schedule__header">
                 <h3>День 1 · Основы реверсивного инжиниринга</h3>
-                <span class="status-chip" data-status="lecture" aria-label="Формат: Лекция">Лекция</span>
+                <span class="status-chip" data-status="lecture" aria-label="Формат: Лекция"
+                  >Лекция</span
+                >
               </header>
               <div class="schedule__meta">
                 <p>История, оборудование, требования к цифровому двойнику.</p>
                 <p>09:30 – 13:00</p>
               </div>
               <div class="schedule__details">
-                <p>Разбор кейсов внедрения аддитивных технологий. Практическое знакомство с оборудованием, обзор ПО.</p>
+                <p>
+                  Разбор кейсов внедрения аддитивных технологий. Практическое знакомство с
+                  оборудованием, обзор ПО.
+                </p>
               </div>
             </article>
             <article class="schedule__item" data-type="practice">
               <header class="schedule__header">
                 <h3>День 2 · Сканирование и подготовка данных</h3>
-                <span class="status-chip" data-status="practice" aria-label="Формат: Практика">Практика</span>
+                <span class="status-chip" data-status="practice" aria-label="Формат: Практика"
+                  >Практика</span
+                >
               </header>
               <div class="schedule__meta">
                 <p>Настройка сканера, построение облаков точек.</p>
                 <p>10:00 – 18:00</p>
               </div>
               <div class="schedule__details">
-                <p>Участники формируют сеточную модель, очищают и выравнивают данные. Разбор типовых ошибок и способов контроля качества.</p>
+                <p>
+                  Участники формируют сеточную модель, очищают и выравнивают данные. Разбор типовых
+                  ошибок и способов контроля качества.
+                </p>
               </div>
             </article>
             <article class="schedule__item" data-type="workshop">
               <header class="schedule__header">
                 <h3>День 3 · Построение CAD-модели</h3>
-                <span class="status-chip" data-status="workshop" aria-label="Формат: Мастер-класс">Мастер-класс</span>
+                <span class="status-chip" data-status="workshop" aria-label="Формат: Мастер-класс"
+                  >Мастер-класс</span
+                >
               </header>
               <div class="schedule__meta">
                 <p>Перенос сетки в CAD, параметрическое моделирование.</p>
                 <p>10:00 – 18:00</p>
               </div>
               <div class="schedule__details">
-                <p>Работа в малых группах с наставником. Подготовка моделей к печати, формирование отчёта для заказчика.</p>
+                <p>
+                  Работа в малых группах с наставником. Подготовка моделей к печати, формирование
+                  отчёта для заказчика.
+                </p>
               </div>
             </article>
             <article class="schedule__item" data-type="exam">
               <header class="schedule__header">
                 <h3>День 4 · Защита проектов</h3>
-                <span class="status-chip" data-status="exam" aria-label="Формат: Экзамен">Экзамен</span>
+                <span class="status-chip" data-status="exam" aria-label="Формат: Экзамен"
+                  >Экзамен</span
+                >
               </header>
               <div class="schedule__meta">
                 <p>Презентация проектов, обратная связь от экспертов.</p>
                 <p>11:00 – 16:00</p>
               </div>
               <div class="schedule__details">
-                <p>Сдача готовых моделей, защита результатов и планов по внедрению. Индивидуальные рекомендации от комиссии.</p>
+                <p>
+                  Сдача готовых моделей, защита результатов и планов по внедрению. Индивидуальные
+                  рекомендации от комиссии.
+                </p>
               </div>
             </article>
           </div>
@@ -489,7 +639,10 @@
                 decoding="async"
               />
               <h3>Алексей Рекут</h3>
-              <p>Руководитель STEP_3D. Эксперт по внедрению аддитивного производства на машиностроительных предприятиях.</p>
+              <p>
+                Руководитель STEP_3D. Эксперт по внедрению аддитивного производства на
+                машиностроительных предприятиях.
+              </p>
             </article>
             <article class="team-card">
               <img
@@ -501,7 +654,10 @@
                 decoding="async"
               />
               <h3>Анастасия Колесникова</h3>
-              <p>Инженер-технолог, наставник по подготовке цифровых двойников и управлению качеством печати.</p>
+              <p>
+                Инженер-технолог, наставник по подготовке цифровых двойников и управлению качеством
+                печати.
+              </p>
             </article>
             <article class="team-card">
               <img
@@ -513,7 +669,10 @@
                 decoding="async"
               />
               <h3>Иван Мальцев</h3>
-              <p>Инженер-конструктор. Специализируется на реверс-инжиниринге сложных деталей и оптимизации конструкции.</p>
+              <p>
+                Инженер-конструктор. Специализируется на реверс-инжиниринге сложных деталей и
+                оптимизации конструкции.
+              </p>
             </article>
           </div>
         </div>
@@ -528,29 +687,68 @@
           <form id="applyForm" class="form" novalidate>
             <div class="form__row">
               <label for="name">ФИО*</label>
-              <input id="name" name="name" type="text" required autocomplete="name" aria-describedby="name-error" />
-              <p class="form__error" id="name-error" role="alert" hidden>Пожалуйста, укажите ФИО.</p>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                required
+                autocomplete="name"
+                aria-describedby="name-error"
+              />
+              <p class="form__error" id="name-error" data-err="name" role="alert" hidden>
+                Пожалуйста, укажите ФИО.
+              </p>
             </div>
             <div class="form__row">
               <label for="email">Электронная почта*</label>
-              <input id="email" name="email" type="email" required autocomplete="email" aria-describedby="email-error" />
-              <p class="form__error" id="email-error" role="alert" hidden>Укажите корректный e-mail.</p>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                autocomplete="email"
+                aria-describedby="email-error"
+              />
+              <p class="form__error" id="email-error" data-err="email" role="alert" hidden>
+                Укажите корректный e-mail.
+              </p>
             </div>
             <div class="form__row">
               <label for="company">Компания</label>
               <input id="company" name="company" type="text" autocomplete="organization" />
             </div>
             <div class="form__row">
-              <label for="message">Комментарий</label>
-              <textarea id="message" name="message" rows="4"></textarea>
+              <label for="comment">Комментарий</label>
+              <textarea id="comment" name="comment" rows="4"></textarea>
             </div>
             <div class="form__consent">
-              <input id="consent" name="consent" type="checkbox" required aria-describedby="consent-desc" />
-              <label for="consent">Согласен(на) на обработку персональных данных</label>
+              <input
+                id="agree"
+                name="agree"
+                type="checkbox"
+                required
+                aria-describedby="consent-desc"
+              />
+              <label for="agree">Согласен(на) на обработку персональных данных</label>
             </div>
-            <p id="consent-desc" class="form__hint">Мы используем данные только для связи по программе.</p>
-            <button type="submit" class="btn-primary" disabled>Отправить</button>
-            <p class="form__success" role="status" hidden>Спасибо! Заявка отправлена, мы свяжемся с вами в ближайшее время.</p>
+            <p id="consent-desc" class="form__hint">
+              Мы используем данные только для связи по программе.
+            </p>
+            <p class="form__error hidden" data-err="agree" role="alert">
+              Нужно согласие на обработку данных.
+            </p>
+            <button
+              type="submit"
+              class="btn-primary submit-btn cursor-not-allowed bg-black/30"
+              id="submitBtn"
+              disabled
+            >
+              Отправить
+            </button>
+            <div id="applyFeedback" class="form__feedback" aria-live="polite"></div>
+            <p class="form__success" role="status" hidden>
+              Спасибо! Заявка отправлена, мы свяжемся с вами в ближайшее время.
+            </p>
           </form>
         </div>
       </section>
@@ -563,27 +761,78 @@
           </div>
           <div class="accordion" role="presentation">
             <div class="accordion__item">
-              <button type="button" aria-expanded="true" aria-controls="faq-panel-1" id="faq-trigger-1">Где проходят занятия?</button>
+              <button
+                type="button"
+                aria-expanded="true"
+                aria-controls="faq-panel-1"
+                id="faq-trigger-1"
+              >
+                Где проходят занятия?
+              </button>
               <div id="faq-panel-1" role="region" aria-labelledby="faq-trigger-1">
-                <p>Очные занятия проходят в технопарке РГСУ (ул. Вильгельма Пика, 4). Онлайн-сессии доступны для дистанционных участников.</p>
+                <p>
+                  Очные занятия проходят в технопарке РГСУ (ул. Вильгельма Пика, 4). Онлайн-сессии
+                  доступны для дистанционных участников.
+                </p>
               </div>
             </div>
             <div class="accordion__item">
-              <button type="button" aria-expanded="false" aria-controls="faq-panel-2" id="faq-trigger-2">Можно ли совмещать с работой?</button>
+              <button
+                type="button"
+                aria-expanded="false"
+                aria-controls="faq-panel-2"
+                id="faq-trigger-2"
+              >
+                Можно ли совмещать с работой?
+              </button>
               <div id="faq-panel-2" role="region" aria-labelledby="faq-trigger-2" hidden>
-                <p>Сессии проходят блоками по два дня в неделю. Практические задания можно выполнять в удобное время с поддержкой наставника.</p>
+                <p>
+                  Сессии проходят блоками по два дня в неделю. Практические задания можно выполнять
+                  в удобное время с поддержкой наставника.
+                </p>
               </div>
             </div>
             <div class="accordion__item">
-              <button type="button" aria-expanded="false" aria-controls="faq-panel-3" id="faq-trigger-3">Нужен ли опыт в CAD?</button>
+              <button
+                type="button"
+                aria-expanded="false"
+                aria-controls="faq-panel-3"
+                id="faq-trigger-3"
+              >
+                Нужен ли опыт в CAD?
+              </button>
               <div id="faq-panel-3" role="region" aria-labelledby="faq-trigger-3" hidden>
-                <p>Будет полезен базовый опыт моделирования, но мы начинаем с фундаментальных инструментов и закрепляем их практикой.</p>
+                <p>
+                  Будет полезен базовый опыт моделирования, но мы начинаем с фундаментальных
+                  инструментов и закрепляем их практикой.
+                </p>
               </div>
             </div>
           </div>
         </div>
       </section>
     </main>
+    <div id="stickyCta" class="sticky-cta hidden" aria-hidden="true" data-dismissed="false">
+      <div class="layout sticky-cta__inner">
+        <div class="sticky-cta__content">
+          <p class="sticky-cta__label">Остались вопросы?</p>
+          <p class="sticky-cta__text">
+            Свяжитесь с нами для консультации и уточнения деталей программы.
+          </p>
+        </div>
+        <div class="sticky-cta__actions">
+          <a class="btn-primary" href="#apply">Оставить заявку</a>
+          <button
+            type="button"
+            class="sticky-cta__dismiss"
+            id="stickyCtaDismiss"
+            aria-label="Скрыть уведомление"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+    </div>
     <footer class="site-footer">
       <div class="layout site-footer__inner">
         <p>© STEP_3D, 2024 · Программа РГСУ 4I.AM.R22</p>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T05:45:26.834Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.9</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#about</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T05:45:26.834Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.6</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#program</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T05:45:26.834Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.7</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#team</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T05:45:26.834Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.6</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#apply</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T05:45:26.834Z</lastmod>
       <changefreq>weekly</changefreq>
       <priority>0.8</priority>
     </url>

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -65,7 +65,9 @@ async function buildTailwind() {
     process.platform === 'win32'
       ? path.join(rootDir, 'node_modules', '.bin', 'tailwindcss.cmd')
       : path.join(rootDir, 'node_modules', '.bin', 'tailwindcss');
-  await execFileAsync(executable, ['-i', inputFile, '-o', outputFile, '--minify', '--postcss'], { cwd: rootDir });
+  await execFileAsync(executable, ['-i', inputFile, '-o', outputFile, '--minify', '--postcss'], {
+    cwd: rootDir,
+  });
 }
 
 async function build() {

--- a/src/main.js
+++ b/src/main.js
@@ -6,16 +6,8 @@ import {
   getCountdownStatus,
   normalizeActivityType,
 } from './utils/course-utils.js';
-import {
-  buildApplicationSummary,
-  createFeedbackCard,
-} from './utils/application-feedback.js';
-import {
-  COURSE_CONFIG,
-  COURSE_START,
-  COURSE_START_ISO,
-  SITE_CONFIG,
-} from './data/course.js';
+import { buildApplicationSummary, createFeedbackCard } from './utils/application-feedback.js';
+import { COURSE_CONFIG, COURSE_START, COURSE_START_ISO, SITE_CONFIG } from './data/course.js';
 
 const siteConfig = SITE_CONFIG ?? {};
 const course = COURSE_CONFIG ?? {};
@@ -405,7 +397,8 @@ const faqItems = [
   },
   {
     question: 'Что происходит на экзамене?',
-    answer: '<p>Итоговый модуль — 16 академических часов практики. Участники выполняют задание компетенции «Реверсивный инжиниринг»: оцифровывают деталь, строят CAD-модель и подготавливают её к аддитивному производству.</p><p class="mt-2">Экзамен завершает программу сертификацией навыков и обратной связью от экспертов.</p>',
+    answer:
+      '<p>Итоговый модуль — 16 академических часов практики. Участники выполняют задание компетенции «Реверсивный инжиниринг»: оцифровывают деталь, строят CAD-модель и подготавливают её к аддитивному производству.</p><p class="mt-2">Экзамен завершает программу сертификацией навыков и обратной связью от экспертов.</p>',
   },
 ];
 const helpfulLinks = [
@@ -588,8 +581,8 @@ function renderStats() {
   const highlightContent = highlightRows
     ? `<dl class="mt-4 space-y-2">${highlightRows}</dl>`
     : course.summary
-    ? `<p class="mt-4 text-sm leading-relaxed text-ink-700">${course.summary}</p>`
-    : '';
+      ? `<p class="mt-4 text-sm leading-relaxed text-ink-700">${course.summary}</p>`
+      : '';
   root.innerHTML = `
     <article class="rounded-3xl border border-black/10 bg-white/85 p-5 shadow-soft backdrop-blur-sm" role="group" aria-labelledby="courseHighlightTitle">
       <div class="text-[11px] font-semibold uppercase tracking-[.3em] text-ink-500">О программе</div>
@@ -709,7 +702,7 @@ function renderTeam() {
   const memberNames = teamMembers.map((member) => member?.name).filter(Boolean);
   const formattedNames =
     memberNames.length <= 1
-      ? memberNames[0] ?? ''
+      ? (memberNames[0] ?? '')
       : `${memberNames.slice(0, -1).join(', ')} и ${memberNames[memberNames.length - 1]}`;
 
   const avatarsMarkup = teamMembers
@@ -896,7 +889,12 @@ function renderTeam() {
   };
   teamCard.addEventListener('click', () => {
     const { markup, headingId } = buildModalContent();
-    openModal({ content: markup, trigger: teamCard, labelId: headingId, announceText: 'Команда курса' });
+    openModal({
+      content: markup,
+      trigger: teamCard,
+      labelId: headingId,
+      announceText: 'Команда курса',
+    });
   });
 }
 function renderTeamShowcase() {
@@ -1200,7 +1198,8 @@ function renderFaq() {
     `;
     const panel = document.createElement('div');
     panel.id = panelId;
-    panel.className = 'faq-answer overflow-hidden px-4 text-sm text-ink-800 transition-[max-height] duration-200 ease-out';
+    panel.className =
+      'faq-answer overflow-hidden px-4 text-sm text-ink-800 transition-[max-height] duration-200 ease-out';
     panel.setAttribute('role', 'region');
     panel.setAttribute('aria-labelledby', controlId);
     panel.setAttribute('aria-hidden', String(!expanded));
@@ -1302,7 +1301,9 @@ function renderProgram(options = {}) {
   const programModules = Array.isArray(options.modules) ? options.modules : modules;
   const root = $('#programRoot');
   if (!root) {
-    console.warn('Контейнер программы (#programRoot) не найден. Секция расписания не будет инициализирована.');
+    console.warn(
+      'Контейнер программы (#programRoot) не найден. Секция расписания не будет инициализирована.',
+    );
     return;
   }
   let view = 'full';
@@ -1371,7 +1372,8 @@ function renderProgram(options = {}) {
     });
   };
   const tabsWrap = document.createElement('div');
-  tabsWrap.className = 'relative border-b border-black/10 bg-white md:sticky md:top-16 md:shadow-sm';
+  tabsWrap.className =
+    'relative border-b border-black/10 bg-white md:sticky md:top-16 md:shadow-sm';
   tabsWrap.innerHTML =
     '<div class="overflow-x-auto px-3 py-2"><div class="flex items-stretch gap-3" id="dayTabs"></div></div>';
   root.appendChild(tabsWrap);
@@ -1446,7 +1448,8 @@ function renderProgram(options = {}) {
       const placeholder = document.createElement('div');
       placeholder.className =
         'rounded-2xl border border-dashed border-black/10 bg-white p-6 text-center text-sm text-ink-700 shadow-sm';
-      placeholder.textContent = 'Скоро появится подробное расписание по дням. Следите за обновлениями!';
+      placeholder.textContent =
+        'Скоро появится подробное расписание по дням. Следите за обновлениями!';
       body.appendChild(placeholder);
       return;
     }
@@ -1521,10 +1524,15 @@ function renderProgram(options = {}) {
           const durationValue = Number(b.durationHours);
           const hasDurationValue = Number.isFinite(durationValue) && durationValue > 0;
           const hasDurationLabel = rawDurationLabel.length > 0 && rawDurationLabel !== '—';
-          const durationLabel = hasDurationLabel ? rawDurationLabel : hasDurationValue ? `${durationValue} ч` : '';
+          const durationLabel = hasDurationLabel
+            ? rawDurationLabel
+            : hasDurationValue
+              ? `${durationValue} ч`
+              : '';
           const durationPill = durationLabel ? renderPill(`⏱ ${durationLabel}`) : '';
           const controlText = String(b.control ?? '').trim();
-          const controlPill = controlText && controlText !== '—' ? renderPill(`✔ ${controlText}`) : '';
+          const controlPill =
+            controlText && controlText !== '—' ? renderPill(`✔ ${controlText}`) : '';
           const typeMeta = typeChipMeta[blockType];
           const typePillLabel = typeMeta?.label ?? 'Формат';
           const typePillTone = typeMeta ? blockType : 'neutral';

--- a/src/utils/application-feedback.js
+++ b/src/utils/application-feedback.js
@@ -20,8 +20,7 @@ export function buildApplicationSummary({ name, email, comment }) {
 
 export function createFeedbackCard(summary) {
   const card = document.createElement('div');
-  card.className =
-    'feedback-card rounded-2xl border border-black/10 bg-white p-4 shadow-soft-md';
+  card.className = 'feedback-card rounded-2xl border border-black/10 bg-white p-4 shadow-soft-md';
   card.setAttribute('data-state', 'hidden');
   card.setAttribute('role', 'status');
 

--- a/src/utils/assistant.js
+++ b/src/utils/assistant.js
@@ -42,9 +42,7 @@ export function getAssistantRecommendations(comment = '') {
   try {
     const normalized = comment.toLocaleLowerCase('ru-RU');
     const matches = normalized
-      ? catalog.filter((module) =>
-          module.keywords.some((keyword) => normalized.includes(keyword)),
-        )
+      ? catalog.filter((module) => module.keywords.some((keyword) => normalized.includes(keyword)))
       : [];
 
     if (matches.length > 0) {

--- a/src/utils/course-utils.js
+++ b/src/utils/course-utils.js
@@ -124,7 +124,7 @@ export function clampIndex(current, delta, length) {
   if (!Number.isFinite(current) || !Number.isFinite(delta) || length <= 0) {
     return 0;
   }
-  const normalized = ((current + delta) % length + length) % length;
+  const normalized = (((current + delta) % length) + length) % length;
   return normalized;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -30,13 +30,24 @@
 }
 
 /* STEP_3D: Reset and typography scale */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  font-family: ui-sans-serif, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
+  font-family:
+    ui-sans-serif,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    'Noto Sans',
+    'Liberation Sans',
+    sans-serif;
   background: var(--bg);
   color: var(--ink);
   font-size: var(--font-sm);
@@ -62,7 +73,10 @@ p {
   margin: 0;
 }
 
-h1, h2, h3, h4 {
+h1,
+h2,
+h3,
+h4 {
   font-weight: 600;
   color: var(--ink);
   margin: 0 0 var(--space-16);
@@ -114,6 +128,49 @@ button:disabled {
   opacity: 0.6;
 }
 
+.hidden {
+  display: none !important;
+}
+
+.cursor-not-allowed {
+  cursor: not-allowed !important;
+}
+
+.bg-black {
+  background-color: #000000 !important;
+  color: #ffffff !important;
+}
+
+.bg-black\/30 {
+  background-color: rgba(0, 0, 0, 0.3) !important;
+  color: #ffffff !important;
+}
+
+.hover\:opacity-90:hover {
+  opacity: 0.9;
+}
+
+.scrollbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: rgba(16, 24, 40, 0.08);
+  z-index: 1000;
+  overflow: hidden;
+}
+
+.scrollbar span {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: var(--brand);
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform 180ms ease;
+}
+
 /* STEP_3D: Layout helpers */
 .layout {
   width: min(1120px, 100% - var(--space-32));
@@ -153,7 +210,9 @@ button:disabled {
 .site-nav__list a {
   font-size: var(--font-sm);
   color: var(--muted);
-  transition: color 150ms ease, opacity 150ms ease;
+  transition:
+    color 150ms ease,
+    opacity 150ms ease;
   padding: 4px 0;
   border-radius: 0;
 }
@@ -193,10 +252,13 @@ button:disabled {
   background: rgba(75, 123, 255, 0.08);
   color: var(--brand);
   border: 1px solid transparent;
-  transition: border-color 150ms ease, background-color 150ms ease, transform 150ms ease;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    transform 150ms ease;
 }
 
-.chip[aria-pressed="true"] {
+.chip[aria-pressed='true'] {
   background: var(--brand);
   color: #ffffff;
   border-color: var(--brand);
@@ -210,7 +272,7 @@ button:disabled {
 .hero__countdown {
   display: flex;
   flex-direction: column;
-  gap: var(--space-8);
+  gap: var(--space-16);
   background: var(--surface);
   padding: var(--space-16);
   border-radius: var(--radius-24);
@@ -220,30 +282,47 @@ button:disabled {
 
 .countdown {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-16);
+  align-items: flex-end;
+  gap: var(--space-12);
 }
 
-.countdown__digit {
-  font-family: "Roboto Mono", SFMono-Regular, ui-monospace, "Liberation Mono", Menlo, monospace;
-  font-size: var(--font-xl);
-  line-height: 1.2;
+.countdown__value {
+  font-family: 'Roboto Mono', SFMono-Regular, ui-monospace, 'Liberation Mono', Menlo, monospace;
+  font-size: clamp(32px, 6vw, 48px);
+  line-height: 1;
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  width: 48px;
-  height: 56px;
+  min-width: 72px;
+  min-height: 64px;
   border-radius: var(--radius-12);
   background: rgba(75, 123, 255, 0.12);
   color: var(--brand);
+  padding: 12px 18px;
 }
 
-.countdown__label {
-  display: block;
-  text-align: center;
-  font-size: var(--font-xs);
+.countdown__unit {
+  font-size: var(--font-sm);
   color: var(--muted);
+  text-transform: lowercase;
+}
+
+.countdown__bar {
+  position: relative;
+  height: 6px;
+  width: 100%;
+  background: rgba(75, 123, 255, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+#countdownBar {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: var(--brand);
+  border-radius: inherit;
+  transition: width 200ms ease;
 }
 
 .hero__meta {
@@ -280,7 +359,10 @@ button:disabled {
   border-radius: 999px;
   padding: 12px var(--space-24);
   text-decoration: none;
-  transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease,
+    background-color 150ms ease;
 }
 
 .btn-primary {
@@ -325,6 +407,117 @@ button:disabled {
   color: var(--muted);
 }
 
+/* STEP_3D: Lead section */
+.lead {
+  background: transparent;
+  padding-top: 0;
+}
+
+.lead__grid {
+  display: grid;
+  gap: var(--space-32);
+}
+
+.lead__card {
+  background: var(--surface);
+  border-radius: var(--radius-24);
+  padding: var(--space-32);
+  box-shadow: var(--shadow-1);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-24);
+}
+
+.lead__list {
+  display: grid;
+  gap: var(--space-16);
+}
+
+.lead__item {
+  display: grid;
+  gap: 4px;
+}
+
+.lead__item dt {
+  font-size: var(--font-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+
+.lead__item dd {
+  margin: 0;
+  font-size: var(--font-md);
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.lead__cta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-16);
+}
+
+.lead__price {
+  font-size: var(--font-xl);
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.lead__price--inline {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-8);
+}
+
+.lead__price--mobile {
+  display: none;
+}
+
+.lead__aside {
+  display: grid;
+  gap: var(--space-24);
+}
+
+.lead__benefits,
+.lead__stats {
+  background: var(--surface);
+  border-radius: var(--radius-24);
+  padding: var(--space-24);
+  box-shadow: var(--shadow-1);
+}
+
+.lead__benefits-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-12);
+  margin-top: var(--space-16);
+}
+
+@media (min-width: 960px) {
+  .lead__grid {
+    grid-template-columns: 1.5fr 1fr;
+    align-items: start;
+  }
+}
+
+@media (max-width: 640px) {
+  .lead__cta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .lead__price--inline {
+    display: none;
+  }
+
+  .lead__price--mobile {
+    display: inline-flex;
+    justify-content: center;
+  }
+}
+
 /* STEP_3D: Carousel */
 .carousel {
   position: relative;
@@ -350,7 +543,7 @@ button:disabled {
   min-height: 420px;
 }
 
-.carousel__slide[aria-hidden="false"] {
+.carousel__slide[aria-hidden='false'] {
   opacity: 1;
   visibility: visible;
 }
@@ -406,7 +599,7 @@ button:disabled {
   background: transparent;
 }
 
-.carousel__dot[aria-selected="true"] {
+.carousel__dot[aria-selected='true'] {
   background: var(--brand);
 }
 
@@ -426,7 +619,9 @@ button:disabled {
   border: none;
   background: transparent;
   color: var(--muted);
-  transition: background-color 150ms ease, color 150ms ease;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease;
 }
 
 .segmented__btn.is-active {
@@ -474,19 +669,19 @@ button:disabled {
   min-height: 28px;
 }
 
-.status-chip[data-status="lecture"] {
+.status-chip[data-status='lecture'] {
   background: var(--status-lecture);
 }
 
-.status-chip[data-status="practice"] {
+.status-chip[data-status='practice'] {
   background: var(--status-practice);
 }
 
-.status-chip[data-status="workshop"] {
+.status-chip[data-status='workshop'] {
   background: var(--status-workshop);
 }
 
-.status-chip[data-status="exam"] {
+.status-chip[data-status='exam'] {
   background: var(--status-exam);
 }
 
@@ -502,14 +697,16 @@ button:disabled {
   max-height: 0;
   overflow: hidden;
   opacity: 0;
-  transition: max-height 180ms ease, opacity 180ms ease;
+  transition:
+    max-height 180ms ease,
+    opacity 180ms ease;
 }
 
-.schedule[data-view="detailed"] .schedule__item {
+.schedule[data-view='detailed'] .schedule__item {
   box-shadow: var(--shadow-2);
 }
 
-.schedule[data-view="detailed"] .schedule__details {
+.schedule[data-view='detailed'] .schedule__details {
   opacity: 1;
 }
 
@@ -585,6 +782,19 @@ button:disabled {
   margin: 0;
 }
 
+.form__feedback {
+  margin-top: var(--space-16);
+}
+
+.submit-btn {
+  margin-top: var(--space-16);
+  min-width: 200px;
+}
+
+.border-red-400 {
+  border-color: #f87171 !important;
+}
+
 .form__success {
   background: rgba(7, 148, 85, 0.1);
   border-radius: var(--radius-12);
@@ -618,6 +828,77 @@ button:disabled {
 .accordion__item > div {
   padding: 0 var(--space-24) var(--space-24);
   color: var(--muted);
+}
+
+/* STEP_3D: Sticky CTA */
+.sticky-cta {
+  position: fixed;
+  inset: auto 0 var(--space-24);
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 850;
+}
+
+.sticky-cta__inner {
+  width: min(640px, 100% - var(--space-32));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-16);
+  background: var(--surface);
+  border-radius: var(--radius-24);
+  box-shadow: var(--shadow-2);
+  padding: var(--space-16) var(--space-24);
+  pointer-events: auto;
+}
+
+.sticky-cta__label {
+  font-size: var(--font-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+
+.sticky-cta__text {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.sticky-cta__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+}
+
+.sticky-cta__dismiss {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: #fff;
+  font-size: var(--font-lg);
+  line-height: 1;
+  color: var(--muted);
+}
+
+.sticky-cta__dismiss:hover {
+  background: var(--brand);
+  color: #fff;
+}
+
+@media (max-width: 640px) {
+  .sticky-cta__inner {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .sticky-cta__actions {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 /* STEP_3D: Footer */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,5 @@
 export default {
-  content: [
-    './index.html',
-    './src/**/*.{js,ts,jsx,tsx,html}',
-    './assets/**/*.{html,js}',
-  ],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx,html}', './assets/**/*.{html,js}'],
   theme: {
     extend: {
       maxWidth: {

--- a/tests/unit/program-render.test.js
+++ b/tests/unit/program-render.test.js
@@ -40,12 +40,7 @@ describe('program rendering', () => {
         { day: '11 (Вт)', blocks: [] },
       ]),
     ).toBe('10 (Пн)');
-    expect(
-      getInitialOpenDay([
-        { day: '  ' },
-        { day: '11 (Вт)', blocks: [] },
-      ]),
-    ).toBe('11 (Вт)');
+    expect(getInitialOpenDay([{ day: '  ' }, { day: '11 (Вт)', blocks: [] }])).toBe('11 (Вт)');
     expect(getInitialOpenDay([])).toBe('');
   });
 


### PR DESCRIPTION
## Summary
- align the hero with course metadata, add the scroll progress bar, and load the Tailwind utility bundle
- introduce a dedicated lead section plus styling hooks for countdown, pricing, and benefits
- update the application form, sticky CTA, and Prettier ignore list to support dynamic behaviour

## Testing
- npm run lint
- npm run format:check
- npm test
- npm run test:e2e *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d38344c24483339e630147e81b8ccd