### PR TITLE
Fix broken hero and gallery imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,29 +262,19 @@
             </div>
             <figure class="hero__media">
               <picture>
-                <source
-                  srcset="images/gallery/printing.avif 640w"
-                  sizes="(min-width: 960px) 480px, 100vw"
-                  type="image/avif"
-                />
-                <source
-                  srcset="images/gallery/printing.webp 640w"
-                  sizes="(min-width: 960px) 480px, 100vw"
-                  type="image/webp"
-                />
                 <img
-                  src="images/gallery/printing.webp"
-                  srcset="images/gallery/printing.webp 640w"
-                  sizes="(min-width: 960px) 480px, 100vw"
-                  width="640"
-                  height="480"
-                  alt="Наставник контролирует процесс 3D-печати"
+                  src="images/gallery/photo_5435945910057165000_y.jpg"
+                  srcset="images/gallery/photo_5435945910057165000_y.jpg 1280w"
+                  sizes="(min-width: 960px) 520px, 100vw"
+                  width="1280"
+                  height="720"
+                  alt="Инженер настраивает роботизированную платформу"
                   loading="eager"
                   fetchpriority="high"
                   decoding="async"
                 />
               </picture>
-              <figcaption class="hero__figure-caption">Практика на промышленных FDM-принтерах</figcaption>
+              <figcaption class="hero__figure-caption">Практика по настройке роботизированной платформы STEP_3D</figcaption>
             </figure>
           </div>
         </div>
@@ -326,82 +316,52 @@
                 <li class="carousel__slide" id="slide-1" role="tabpanel" aria-labelledby="dot-1">
                   <figure>
                     <picture>
-                      <source
-                        srcset="images/gallery/scan-station.avif 640w"
-                        sizes="(min-width: 960px) 560px, 100vw"
-                        type="image/avif"
-                      />
-                      <source
-                        srcset="images/gallery/scan-station.webp 640w"
-                        sizes="(min-width: 960px) 560px, 100vw"
-                        type="image/webp"
-                      />
                       <img
-                        src="images/gallery/scan-station.webp"
-                        srcset="images/gallery/scan-station.webp 640w"
+                        src="images/gallery/photo_5435945910057165000_y.jpg"
+                        srcset="images/gallery/photo_5435945910057165000_y.jpg 1280w"
                         sizes="(min-width: 960px) 560px, 100vw"
-                        width="640"
-                        height="480"
-                        alt="Студент учится сканировать корпус детали"
+                        width="1280"
+                        height="720"
+                        alt="Инженер настраивает роботизированную платформу"
                         loading="lazy"
                         decoding="async"
                       />
                     </picture>
-                    <figcaption>Сканирование деталей на оптическом стенде</figcaption>
+                    <figcaption>Настройка и калибровка роботизированной платформы</figcaption>
                   </figure>
                 </li>
                 <li class="carousel__slide" id="slide-2" role="tabpanel" aria-labelledby="dot-2">
                   <figure>
                     <picture>
-                      <source
-                        srcset="images/gallery/cad-model.avif 640w"
-                        sizes="(min-width: 960px) 560px, 100vw"
-                        type="image/avif"
-                      />
-                      <source
-                        srcset="images/gallery/cad-model.webp 640w"
-                        sizes="(min-width: 960px) 560px, 100vw"
-                        type="image/webp"
-                      />
                       <img
-                        src="images/gallery/cad-model.webp"
-                        srcset="images/gallery/cad-model.webp 640w"
+                        src="images/gallery/gallery-workshop-01.jpg"
+                        srcset="images/gallery/gallery-workshop-01.jpg 1110w"
                         sizes="(min-width: 960px) 560px, 100vw"
-                        width="640"
-                        height="480"
-                        alt="Группа студентов обсуждает CAD-модель на экране"
+                        width="1110"
+                        height="733"
+                        alt="Прототип детали после 3D-печати и постобработки"
                         loading="lazy"
                         decoding="async"
                       />
                     </picture>
-                    <figcaption>Командная работа над CAD-моделями</figcaption>
+                    <figcaption>Прототип детали после 3D-печати и постобработки</figcaption>
                   </figure>
                 </li>
                 <li class="carousel__slide" id="slide-3" role="tabpanel" aria-labelledby="dot-3">
                   <figure>
                     <picture>
-                      <source
-                        srcset="images/gallery/printing.avif 640w"
-                        sizes="(min-width: 960px) 560px, 100vw"
-                        type="image/avif"
-                      />
-                      <source
-                        srcset="images/gallery/printing.webp 640w"
-                        sizes="(min-width: 960px) 560px, 100vw"
-                        type="image/webp"
-                      />
                       <img
-                        src="images/gallery/printing.webp"
-                        srcset="images/gallery/printing.webp 640w"
+                        src="images/gallery/photo_5462921397052501528_y.jpg"
+                        srcset="images/gallery/photo_5462921397052501528_y.jpg 720w"
                         sizes="(min-width: 960px) 560px, 100vw"
-                        width="640"
-                        height="480"
-                        alt="Наставник демонстрирует параметры 3D-печати"
+                        width="720"
+                        height="1280"
+                        alt="Авторская 3D-печатная скульптура в технопарке"
                         loading="lazy"
                         decoding="async"
                       />
                     </picture>
-                    <figcaption>Настройка печати и постобработка моделей</figcaption>
+                    <figcaption>Авторская 3D-печатная скульптура в технопарке</figcaption>
                   </figure>
                 </li>
               </ul>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T06:38:01.267Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.9</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#about</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T06:38:01.267Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.6</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#program</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T06:38:01.267Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.7</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#team</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T06:38:01.267Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.6</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#apply</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T06:38:01.267Z</lastmod>
       <changefreq>weekly</changefreq>
       <priority>0.8</priority>
     </url>


### PR DESCRIPTION
## Summary
- swap invalid AVIF placeholders in the hero and gallery with working JPEG photos and refreshed captions
- update sitemap timestamps to reflect the new content deployment

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d389c4cae483339b6f1d7fbf171f5e