### PR TITLE
Refactor Orbit Invaders assets

### DIFF
--- a/app.js
+++ b/app.js
@@ -320,3 +320,83 @@ if (accordionButtons.length) {
 if (accordionButtons.length) {
   openAccordionItem(accordionButtons[0]);
 }
+
+// STEP_3D: Orbit Invaders animation
+const orbitRoot = document.getElementById('orbitInvaders');
+
+if (orbitRoot) {
+  const layer = orbitRoot.querySelector('.orbit-layer');
+  const cube = orbitRoot.querySelector('.center-cube');
+  if (layer) {
+    const COUNT = Number.parseInt(orbitRoot.dataset.count ?? '12', 10) || 12;
+    const SPEED = Number.parseFloat(orbitRoot.dataset.speed ?? '0.6') || 0.6;
+    const RATIO = Number.parseFloat(orbitRoot.dataset.radius ?? '42') || 42;
+
+    const makeInvader = (fill = '#64748b') => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('viewBox', '0 0 16 12');
+      svg.classList.add('invader');
+      const parts = [
+        [0, 4, 2, 2, '#475569'],
+        [14, 4, 2, 2, '#475569'],
+        [2, 2, 12, 8, fill],
+        [4, 0, 8, 4, fill],
+        [4, 4, 2, 2, '#0f172a'],
+        [10, 4, 2, 2, '#0f172a'],
+        [0, 10, 4, 2, fill],
+        [12, 10, 4, 2, fill],
+      ];
+      parts.forEach(([x, y, w, h, color]) => {
+        const rect = document.createElementNS(svg.namespaceURI, 'rect');
+        rect.setAttribute('x', String(x));
+        rect.setAttribute('y', String(y));
+        rect.setAttribute('width', String(w));
+        rect.setAttribute('height', String(h));
+        rect.setAttribute('fill', color);
+        svg.appendChild(rect);
+      });
+      return svg;
+    };
+
+    const nodes = [];
+    for (let i = 0; i < COUNT; i += 1) {
+      const node = document.createElement('div');
+      node.className = 'invader-node';
+      const hue = 210 + ((i * 12) % 140);
+      const invader = makeInvader(`hsl(${hue} 16% 60%)`);
+      node.appendChild(invader);
+      layer.appendChild(node);
+      nodes.push({ node, angle: (i / COUNT) * Math.PI * 2 });
+    }
+
+    let startTimestamp = null;
+    const animate = (timestamp) => {
+      if (startTimestamp === null) startTimestamp = timestamp;
+      const elapsedSeconds = (timestamp - startTimestamp) / 1000;
+      const { width, height } = orbitRoot.getBoundingClientRect();
+      const cx = width / 2;
+      const cy = height / 2;
+      const radius = Math.min(cx, cy) * (RATIO / 50);
+      const angularVelocity = SPEED * Math.PI * 2;
+      nodes.forEach((entry, index) => {
+        const angle = entry.angle + angularVelocity * elapsedSeconds * (index % 2 === 0 ? 0.92 : 1);
+        const x = cx + radius * Math.cos(angle);
+        const y = cy + radius * Math.sin(angle);
+        const tangent = angle + Math.PI / 2;
+        entry.node.style.transform = `translate(${x}px, ${y}px) rotate(${tangent}rad)`;
+      });
+      window.requestAnimationFrame(animate);
+    };
+
+    window.requestAnimationFrame(animate);
+
+    if (cube) {
+      orbitRoot.addEventListener('click', () => {
+        cube.style.animation = 'none';
+        // Force reflow to replay the animation
+        void cube.offsetWidth;
+        cube.style.animation = '';
+      });
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -621,6 +621,32 @@
           </div>
         </div>
       </section>
+      <!-- STEP_3D: Orbit Invaders interactive -->
+      <section class="section" aria-labelledby="section-invaders">
+        <div class="layout stack">
+          <div class="section__header">
+            <p class="eyebrow">Технологии в действии</p>
+            <h2 id="section-invaders">Orbit Invaders</h2>
+          </div>
+          <p>
+            Небольшой космический перерыв: пиксельные «захватчики» кружат вокруг куба, демонстрируя работу с анимацией и SVG.
+          </p>
+          <!-- === ORBIT INVADERS (drop-in) =================================== -->
+          <div
+            class="orbit-invaders"
+            id="orbitInvaders"
+            data-count="12"
+            data-speed="0.6"
+            data-radius="42"
+          >
+            <div class="center-cube" aria-hidden="true"></div>
+            <div class="orbit-ring" aria-hidden="true"></div>
+            <div class="orbit-layer" aria-hidden="true"></div>
+            <p class="sr-only">Анимация: пиксельные «космические захватчики» движутся по круговой орбите вокруг белого куба в центре.</p>
+          </div>
+          <!-- === /ORBIT INVADERS ============================================ -->
+        </div>
+      </section>
     </main>
     <footer class="site-footer">
       <div class="layout site-footer__inner">

--- a/styles.css
+++ b/styles.css
@@ -695,6 +695,141 @@ button:disabled {
   color: var(--muted);
 }
 
+/* STEP_3D: Orbit Invaders showcase */
+.orbit-invaders {
+  position: relative;
+  width: min(520px, 90vw);
+  aspect-ratio: 1 / 1;
+  margin: auto;
+  border-radius: var(--radius-24);
+  background: radial-gradient(120% 120% at 70% 30%, #f1f5f9, #e2e8f0 60%, #f8fafc 100%);
+  border: 1px solid #e2e8f0;
+  box-shadow: inset 0 10px 30px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.orbit-ring {
+  position: absolute;
+  inset: 0;
+}
+
+.orbit-ring::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  translate: -50% -50%;
+  width: 70%;
+  height: 70%;
+  border-radius: 50%;
+  border: 1px dashed rgba(100, 116, 139, 0.35);
+}
+
+.center-cube {
+  --orbit-cube-size: 110px;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: var(--orbit-cube-size);
+  height: var(--orbit-cube-size);
+  translate: -50% -50%;
+  background: #fff;
+  border-radius: 20px;
+  box-shadow:
+    0 10px 30px rgba(15, 23, 42, 0.18),
+    inset 0 2px 0 rgba(255, 255, 255, 0.8);
+  transform: rotate(45deg) scale(0.001);
+  animation: cube-impact 900ms cubic-bezier(0.2, 0.9, 0.1, 1.2) forwards;
+}
+
+@keyframes cube-impact {
+  0% {
+    transform: rotate(45deg) scale(0.001) translateZ(0);
+  }
+
+  60% {
+    transform: rotate(45deg) scale(1.12);
+  }
+
+  80% {
+    transform: rotate(45deg) scale(0.92);
+  }
+
+  100% {
+    transform: rotate(45deg) scale(1);
+  }
+}
+
+.center-cube::after {
+  content: "";
+  position: absolute;
+  inset: -14%;
+  border-radius: 28px;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.55), transparent 60%);
+  filter: blur(12px);
+  animation: cube-glow 2.6s ease-in-out 1s infinite;
+}
+
+@keyframes cube-glow {
+  0%,
+  100% {
+    opacity: 0.65;
+  }
+
+  50% {
+    opacity: 0.2;
+  }
+}
+
+@media (max-width: 520px) {
+  .center-cube {
+    --orbit-cube-size: 92px;
+  }
+}
+
+.orbit-layer {
+  position: absolute;
+  inset: 0;
+}
+
+.invader-node {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 0;
+  height: 0;
+  will-change: transform;
+}
+
+.invader {
+  width: 28px;
+  height: 22px;
+  translate: -50% -50%;
+  filter: drop-shadow(0 2px 6px rgba(2, 6, 23, 0.25));
+  will-change: transform;
+  transition: transform 200ms ease;
+}
+
+.invader:hover {
+  transform: scale(1.1);
+}
+
+@media (max-width: 520px) {
+  .invader {
+    width: 24px;
+    height: 19px;
+  }
+}
+
+.orbit-invaders .sr-only {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
 /* STEP_3D: Footer */
 .site-footer {
   background: var(--ink);


### PR DESCRIPTION
## Summary
- keep the Orbit Invaders markup lean by removing inline style and script blocks
- add dedicated Orbit Invaders styling to the shared stylesheet
- integrate the Orbit Invaders animation logic into the global app.js bundle with graceful fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3a3a6ef1883338a3e8b0ff4fc794e