### PR TITLE
feat(site): add reverse engineering course page

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,7 +35,9 @@ if (featureChips.length) {
 // STEP_3D: Countdown timer with reserved width
 const countdownRoot = document.querySelector('[data-countdown]');
 if (countdownRoot) {
-  const targetDate = new Date('2025-10-20T09:00:00+03:00');
+  const targetDateIso = '2025-10-20T09:00:00+03:00';
+  const targetDate = new Date(targetDateIso);
+  countdownRoot.setAttribute('data-start', targetDateIso);
   const daysNode = countdownRoot.querySelector('[data-days]');
   const hoursNode = countdownRoot.querySelector('[data-hours]');
   const minutesNode = countdownRoot.querySelector('[data-minutes]');
@@ -199,7 +201,7 @@ window.addEventListener('resize', () => {
 const form = document.getElementById('applyForm');
 if (form) {
   const submitButton = form.querySelector('button[type="submit"]');
-  const consent = form.querySelector('#consent');
+  const consent = form.querySelector('#agree, #consent');
   const successMessage = form.querySelector('.form__success');
   const requiredFields = Array.from(form.querySelectorAll('input[required][type!="checkbox"], textarea[required]'));
   const errorMap = new Map(
@@ -222,11 +224,8 @@ if (form) {
   const validateField = (field) => {
     const errorNode = errorMap.get(field);
     if (!errorNode) return;
-    if (field.validity.valid) {
-      errorNode.hidden = true;
-    } else {
-      errorNode.hidden = false;
-    }
+    const shouldHide = field.validity.valid;
+    errorNode.classList.toggle('is-hidden', shouldHide);
   };
 
   requiredFields.forEach((field) => {

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T09:37:49.246Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.9</priority>
     </url>
     <url>
+      <loc>https://step3dlab.github.io/4I.AM.R22/reverse-engineering.html</loc>
+      <lastmod>2025-09-24T09:37:49.246Z</lastmod>
+      <changefreq>monthly</changefreq>
+      <priority>0.85</priority>
+    </url>
+    <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#about</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T09:37:49.246Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.6</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#program</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T09:37:49.246Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.7</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#team</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T09:37:49.246Z</lastmod>
       <changefreq>monthly</changefreq>
       <priority>0.6</priority>
     </url>
     <url>
       <loc>https://step3dlab.github.io/4I.AM.R22/#apply</loc>
-      <lastmod>2025-09-21T15:45:16.442Z</lastmod>
+      <lastmod>2025-09-24T09:37:49.246Z</lastmod>
       <changefreq>weekly</changefreq>
       <priority>0.8</priority>
     </url>

--- a/reverse-engineering.html
+++ b/reverse-engineering.html
@@ -11,8 +11,8 @@
     <meta name="theme-color" content="#ffffff" />
     <meta name="robots" content="index, follow" />
     <meta name="color-scheme" content="light" />
-    <link rel="canonical" href="https://step3dlab.github.io/4I.AM.R22/" />
-    <meta property="og:url" content="https://step3dlab.github.io/4I.AM.R22/" />
+    <link rel="canonical" href="https://step3dlab.github.io/4I.AM.R22/reverse-engineering.html" />
+    <meta property="og:url" content="https://step3dlab.github.io/4I.AM.R22/reverse-engineering.html" />
     <meta property="og:title" content="Реверсивный инжиниринг и АТ — интенсив" />
     <meta
       property="og:description"

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -72,7 +72,7 @@ async function build() {
   await rm(distDir, { recursive: true, force: true });
   await mkdir(distDir, { recursive: true });
   await generateSitemap();
-  const assetsToCopy = ['index.html', 'src', 'images', 'public', 'assets'];
+  const assetsToCopy = ['index.html', 'reverse-engineering.html', 'src', 'images', 'public', 'assets'];
   for (const asset of assetsToCopy) {
     await copyIfExists(asset);
   }

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -36,6 +36,7 @@ const BASE_WITH_TRAILING_SLASH = baseUrl.href.endsWith('/') ? baseUrl.href : `${
 
 const pages = [
   { loc: '/', priority: 0.9, changefreq: 'monthly' },
+  { loc: '/reverse-engineering.html', priority: 0.85, changefreq: 'monthly' },
   { loc: '/#about', priority: 0.6, changefreq: 'monthly' },
   { loc: '/#program', priority: 0.7, changefreq: 'monthly' },
   { loc: '/#team', priority: 0.6, changefreq: 'monthly' },

--- a/styles.css
+++ b/styles.css
@@ -660,6 +660,10 @@ button:disabled {
   margin: 0;
 }
 
+.form__error.is-hidden {
+  display: none;
+}
+
 .form__success {
   background: rgba(7, 148, 85, 0.1);
   border-radius: var(--radius-12);


### PR DESCRIPTION
## Summary
- add a standalone `reverse-engineering.html` page that mirrors the current landing layout with course-specific metadata
- expose countdown metadata and align application form fields with Playwright expectations across pages
- copy the new page in the build, publish it via the sitemap, and tweak form error styling for runtime toggling

## Testing
- npm run lint
- npm run test
- npm run build
- npm run test:e2e
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d3b80a7e8883339667cdafd6a26459