### PR TITLE
feat: add program overview and rental form

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
           <div class="hero__grid">
             <div class="hero__content">
               <p class="eyebrow" data-course-tagline>Программа повышения квалификации РГСУ × STEP_3D</p>
-              <h1 id="section-hero" class="hero__title">Реверсивный инжиниринг и аддитивное производство</h1>
+              <h1 id="section-hero" class="hero__title shimmer-text">Реверсивный инжиниринг и аддитивное производство</h1>
               <p class="hero__lead" data-course-summary>
                 Интенсив на 72 часа: сканирование, обработка облаков точек, моделирование и 3D-печать с наставниками
                 производства.
@@ -280,6 +280,7 @@
               <div class="hero__actions">
                 <a class="btn-primary" href="#apply">Записаться</a>
                 <a class="btn-secondary" href="#program">Смотреть программу</a>
+                <a class="btn-secondary" href="reverse-engineering.html">Подробнее о курсе</a>
               </div>
             </div>
             <figure class="hero__media">
@@ -330,6 +331,70 @@
             <article class="feature-card" role="listitem">
               <h3>Сертификат РГСУ</h3>
               <p>По итогам программы выдаётся удостоверение о повышении квалификации установленного образца.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+      <!-- STEP_3D: Programs overview -->
+      <section id="programs-overview" class="section" aria-labelledby="section-programs-overview">
+        <div class="layout stack">
+          <div class="section__header">
+            <p class="eyebrow">Образовательные треки STEP_3D</p>
+            <h2 id="section-programs-overview">Актуальные программы технопарка</h2>
+          </div>
+          <div class="program-card-grid">
+            <article class="program-card program-card--highlight">
+              <div class="program-card__header">
+                <p class="program-card__eyebrow">Повышение квалификации</p>
+                <h3 class="program-card__title shimmer-text">Реверсивный инжиниринг и аддитивное производство</h3>
+              </div>
+              <p class="program-card__description">
+                CAD, прототипирование, аддитивные технологии. Практика 3D-сканирования, моделирования и печати с наставниками
+                STEP_3D.
+              </p>
+              <dl class="program-card__meta">
+                <div class="program-card__meta-item">
+                  <dt>Длительность</dt>
+                  <dd>72 академических часа</dd>
+                </div>
+                <div class="program-card__meta-item">
+                  <dt>Аудитория</dt>
+                  <dd>7–11 класс, студенты и молодые инженеры</dd>
+                </div>
+              </dl>
+              <div class="program-card__actions">
+                <a class="btn-primary" href="#apply">Записаться</a>
+                <a class="btn-secondary" href="reverse-engineering.html">Подробнее</a>
+              </div>
+            </article>
+            <article class="program-card">
+              <div class="program-card__header">
+                <p class="program-card__eyebrow">Дополнительное образование</p>
+                <h3 class="program-card__title">Инженерная школа</h3>
+              </div>
+              <p class="program-card__description">
+                CAD, прототипирование, аддитивные технологии и проектная работа для школьников и студентов.
+              </p>
+              <dl class="program-card__meta">
+                <div class="program-card__meta-item">
+                  <dt>Длительность</dt>
+                  <dd>72 академических часа</dd>
+                </div>
+                <div class="program-card__meta-item">
+                  <dt>Аудитория</dt>
+                  <dd>7–11 класс, студенты</dd>
+                </div>
+              </dl>
+              <div class="program-card__actions">
+                <a
+                  class="btn-secondary"
+                  href="https://technopark-rgsu.ru/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Сайт технопарка РГСУ
+                </a>
+              </div>
             </article>
           </div>
         </div>
@@ -431,6 +496,58 @@
               <div class="carousel__dots" role="tablist" aria-label="Выбор слайда"></div>
             </div>
           </section>
+        </div>
+      </section>
+      <!-- STEP_3D: Equipment and software -->
+      <section id="equipment" class="section" aria-labelledby="section-equipment">
+        <div class="layout stack">
+          <div class="section__header">
+            <p class="eyebrow">Инфраструктура</p>
+            <h2 id="section-equipment">Оборудование и ПО</h2>
+          </div>
+          <div class="equipment-grid" role="list">
+            <article class="equipment-card" role="listitem">
+              <h3>Оборудование лаборатории</h3>
+              <ul class="equipment-list">
+                <li>3D-сканеры RangeVision Spectrum, Artec Eva, Leica для точного оцифровывания деталей.</li>
+                <li>Промышленные FDM/DLP/SLA-принтеры PICASO 3D, Creality, Anycubic для изготовления мастер-моделей.</li>
+                <li>Станки с ЧПУ и постобработка: пескоструй, галтование, инструментальная оснастка.</li>
+              </ul>
+            </article>
+            <article class="equipment-card" role="listitem">
+              <h3>Программное обеспечение</h3>
+              <ul class="equipment-list">
+                <li>Geomagic Design X и Control X для реверсивного инжиниринга и контроля качества.</li>
+                <li>T-FLEX CAD, Autodesk Fusion 360, КОМПАС-3D для параметрического моделирования.</li>
+                <li>Ultimaker Cura, CHITUBOX, Polygon X для подготовки печати и сопровождения производства.</li>
+              </ul>
+            </article>
+          </div>
+          <form id="rentForm" class="form form--compact rent-form" action="#" method="post" aria-describedby="rentNote rentHint">
+            <h3 class="form__title">Аренда мощностей STEP_3D</h3>
+            <p class="rent-form__note" id="rentNote">
+              Стоимость аренды — 5 000 ₽ за один день. Можно пользоваться любым оборудованием и ПО лаборатории со своими
+              расходниками.
+            </p>
+            <div class="form__row">
+              <label for="rentName">ФИО*</label>
+              <input id="rentName" name="name" type="text" required autocomplete="name" />
+            </div>
+            <div class="form__row">
+              <label for="rentContact">Телефон или e-mail*</label>
+              <input id="rentContact" name="contact" type="text" required />
+            </div>
+            <div class="form__row">
+              <label for="rentDate">Желаемая дата аренды</label>
+              <input id="rentDate" name="date" type="date" />
+            </div>
+            <div class="form__row">
+              <label for="rentComment">Оборудование или задачи</label>
+              <textarea id="rentComment" name="comment" rows="3"></textarea>
+            </div>
+            <p class="rent-form__hint" id="rentHint">Менеджер свяжется с вами, уточнит детали и забронирует рабочие места.</p>
+            <button type="submit" class="btn-primary">Отправить запрос</button>
+          </form>
         </div>
       </section>
       <!-- STEP_3D: Program and schedule -->
@@ -544,6 +661,23 @@
               <h3>Иван Мальцев</h3>
               <p>Инженер-конструктор. Специализируется на реверс-инжиниринге сложных деталей и оптимизации конструкции.</p>
             </article>
+          </div>
+          <div class="team-video">
+            <a
+              class="team-video__link"
+              href="images/gallery/document_5395774681049485053.mp4"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <span class="team-video__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="img" focusable="false">
+                  <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="1.5" />
+                  <path d="M10 8.5v7l6-3.5-6-3.5z" fill="currentColor" />
+                </svg>
+              </span>
+              <span>Видео о технопарке РГСУ</span>
+            </a>
+            <p class="team-video__note">Посмотрите, как устроено пространство STEP_3D и лаборатории технопарка.</p>
           </div>
         </div>
       </section>

--- a/reverse-engineering.html
+++ b/reverse-engineering.html
@@ -237,7 +237,7 @@
           <div class="hero__grid">
             <div class="hero__content">
               <p class="eyebrow" data-course-tagline>Программа повышения квалификации РГСУ × STEP_3D</p>
-              <h1 id="section-hero" class="hero__title">Реверсивный инжиниринг и аддитивное производство</h1>
+              <h1 id="section-hero" class="hero__title shimmer-text">Реверсивный инжиниринг и аддитивное производство</h1>
               <p class="hero__lead" data-course-summary>
                 Интенсив на 72 часа: сканирование, обработка облаков точек, моделирование и 3D-печать с наставниками
                 производства.
@@ -280,6 +280,7 @@
               <div class="hero__actions">
                 <a class="btn-primary" href="#apply">Записаться</a>
                 <a class="btn-secondary" href="#program">Смотреть программу</a>
+                <a class="btn-secondary" href="index.html">Вернуться на главную</a>
               </div>
             </div>
             <figure class="hero__media">
@@ -330,6 +331,70 @@
             <article class="feature-card" role="listitem">
               <h3>Сертификат РГСУ</h3>
               <p>По итогам программы выдаётся удостоверение о повышении квалификации установленного образца.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+      <!-- STEP_3D: Programs overview -->
+      <section id="programs-overview" class="section" aria-labelledby="section-programs-overview">
+        <div class="layout stack">
+          <div class="section__header">
+            <p class="eyebrow">Образовательные треки STEP_3D</p>
+            <h2 id="section-programs-overview">Актуальные программы технопарка</h2>
+          </div>
+          <div class="program-card-grid">
+            <article class="program-card program-card--highlight">
+              <div class="program-card__header">
+                <p class="program-card__eyebrow">Повышение квалификации</p>
+                <h3 class="program-card__title shimmer-text">Реверсивный инжиниринг и аддитивное производство</h3>
+              </div>
+              <p class="program-card__description">
+                CAD, прототипирование, аддитивные технологии. Практика 3D-сканирования, моделирования и печати с наставниками
+                STEP_3D.
+              </p>
+              <dl class="program-card__meta">
+                <div class="program-card__meta-item">
+                  <dt>Длительность</dt>
+                  <dd>72 академических часа</dd>
+                </div>
+                <div class="program-card__meta-item">
+                  <dt>Аудитория</dt>
+                  <dd>7–11 класс, студенты и молодые инженеры</dd>
+                </div>
+              </dl>
+              <div class="program-card__actions">
+                <a class="btn-primary" href="#apply">Записаться</a>
+                <a class="btn-secondary" href="reverse-engineering.html">Подробнее</a>
+              </div>
+            </article>
+            <article class="program-card">
+              <div class="program-card__header">
+                <p class="program-card__eyebrow">Дополнительное образование</p>
+                <h3 class="program-card__title">Инженерная школа</h3>
+              </div>
+              <p class="program-card__description">
+                CAD, прототипирование, аддитивные технологии и проектная работа для школьников и студентов.
+              </p>
+              <dl class="program-card__meta">
+                <div class="program-card__meta-item">
+                  <dt>Длительность</dt>
+                  <dd>72 академических часа</dd>
+                </div>
+                <div class="program-card__meta-item">
+                  <dt>Аудитория</dt>
+                  <dd>7–11 класс, студенты</dd>
+                </div>
+              </dl>
+              <div class="program-card__actions">
+                <a
+                  class="btn-secondary"
+                  href="https://technopark-rgsu.ru/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Сайт технопарка РГСУ
+                </a>
+              </div>
             </article>
           </div>
         </div>
@@ -431,6 +496,58 @@
               <div class="carousel__dots" role="tablist" aria-label="Выбор слайда"></div>
             </div>
           </section>
+        </div>
+      </section>
+      <!-- STEP_3D: Equipment and software -->
+      <section id="equipment" class="section" aria-labelledby="section-equipment">
+        <div class="layout stack">
+          <div class="section__header">
+            <p class="eyebrow">Инфраструктура</p>
+            <h2 id="section-equipment">Оборудование и ПО</h2>
+          </div>
+          <div class="equipment-grid" role="list">
+            <article class="equipment-card" role="listitem">
+              <h3>Оборудование лаборатории</h3>
+              <ul class="equipment-list">
+                <li>3D-сканеры RangeVision Spectrum, Artec Eva, Leica для точного оцифровывания деталей.</li>
+                <li>Промышленные FDM/DLP/SLA-принтеры PICASO 3D, Creality, Anycubic для изготовления мастер-моделей.</li>
+                <li>Станки с ЧПУ и постобработка: пескоструй, галтование, инструментальная оснастка.</li>
+              </ul>
+            </article>
+            <article class="equipment-card" role="listitem">
+              <h3>Программное обеспечение</h3>
+              <ul class="equipment-list">
+                <li>Geomagic Design X и Control X для реверсивного инжиниринга и контроля качества.</li>
+                <li>T-FLEX CAD, Autodesk Fusion 360, КОМПАС-3D для параметрического моделирования.</li>
+                <li>Ultimaker Cura, CHITUBOX, Polygon X для подготовки печати и сопровождения производства.</li>
+              </ul>
+            </article>
+          </div>
+          <form id="rentForm" class="form form--compact rent-form" action="#" method="post" aria-describedby="rentNote rentHint">
+            <h3 class="form__title">Аренда мощностей STEP_3D</h3>
+            <p class="rent-form__note" id="rentNote">
+              Стоимость аренды — 5 000 ₽ за один день. Можно пользоваться любым оборудованием и ПО лаборатории со своими
+              расходниками.
+            </p>
+            <div class="form__row">
+              <label for="rentName">ФИО*</label>
+              <input id="rentName" name="name" type="text" required autocomplete="name" />
+            </div>
+            <div class="form__row">
+              <label for="rentContact">Телефон или e-mail*</label>
+              <input id="rentContact" name="contact" type="text" required />
+            </div>
+            <div class="form__row">
+              <label for="rentDate">Желаемая дата аренды</label>
+              <input id="rentDate" name="date" type="date" />
+            </div>
+            <div class="form__row">
+              <label for="rentComment">Оборудование или задачи</label>
+              <textarea id="rentComment" name="comment" rows="3"></textarea>
+            </div>
+            <p class="rent-form__hint" id="rentHint">Менеджер свяжется с вами, уточнит детали и забронирует рабочие места.</p>
+            <button type="submit" class="btn-primary">Отправить запрос</button>
+          </form>
         </div>
       </section>
       <!-- STEP_3D: Program and schedule -->
@@ -544,6 +661,23 @@
               <h3>Иван Мальцев</h3>
               <p>Инженер-конструктор. Специализируется на реверс-инжиниринге сложных деталей и оптимизации конструкции.</p>
             </article>
+          </div>
+          <div class="team-video">
+            <a
+              class="team-video__link"
+              href="images/gallery/document_5395774681049485053.mp4"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <span class="team-video__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="img" focusable="false">
+                  <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="1.5" />
+                  <path d="M10 8.5v7l6-3.5-6-3.5z" fill="currentColor" />
+                </svg>
+              </span>
+              <span>Видео о технопарке РГСУ</span>
+            </a>
+            <p class="team-video__note">Посмотрите, как устроено пространство STEP_3D и лаборатории технопарка.</p>
           </div>
         </div>
       </section>

--- a/styles.css
+++ b/styles.css
@@ -315,6 +315,44 @@ button:disabled {
   background: rgba(75, 123, 255, 0.08);
 }
 
+/* STEP_3D: Animated shimmer */
+.shimmer-text {
+  color: var(--ink);
+  position: relative;
+}
+
+@supports (-webkit-background-clip: text) or (background-clip: text) {
+  .shimmer-text {
+    background-image: linear-gradient(120deg, var(--ink), #6c8cff, var(--ink));
+    background-size: 200% 100%;
+    color: transparent;
+    background-clip: text;
+    -webkit-background-clip: text;
+    animation: shimmer 6s ease-in-out infinite;
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @supports (-webkit-background-clip: text) or (background-clip: text) {
+    .shimmer-text {
+      animation: none;
+      background-position: 50% 50%;
+    }
+  }
+}
+
 /* STEP_3D: Feature cards */
 .feature-grid {
   display: grid;
@@ -333,6 +371,122 @@ button:disabled {
 
 .feature-card p {
   color: var(--muted);
+}
+
+/* STEP_3D: Program cards */
+.program-card-grid {
+  display: grid;
+  gap: var(--space-24);
+}
+
+.program-card {
+  background: var(--surface);
+  border-radius: var(--radius-24);
+  padding: var(--space-32);
+  box-shadow: var(--shadow-1);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-24);
+}
+
+.program-card--highlight {
+  border-color: rgba(75, 123, 255, 0.35);
+  background: linear-gradient(140deg, rgba(75, 123, 255, 0.08), rgba(75, 123, 255, 0.02));
+  box-shadow: var(--shadow-2);
+}
+
+.program-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.program-card__eyebrow {
+  font-size: var(--font-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+
+.program-card__description {
+  margin: 0;
+  color: var(--muted);
+}
+
+.program-card__meta {
+  display: grid;
+  gap: var(--space-16);
+  margin: 0;
+}
+
+.program-card__meta-item {
+  display: grid;
+  gap: 4px;
+}
+
+.program-card__meta-item dt {
+  font-size: var(--font-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+
+.program-card__meta-item dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.program-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-16);
+}
+
+/* STEP_3D: Equipment */
+.equipment-grid {
+  display: grid;
+  gap: var(--space-24);
+}
+
+.equipment-card {
+  background: var(--surface);
+  border-radius: var(--radius-24);
+  padding: var(--space-24);
+  box-shadow: var(--shadow-1);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+}
+
+.equipment-card h3 {
+  margin: 0;
+}
+
+.equipment-list {
+  margin: 0;
+  padding-left: var(--space-24);
+  color: var(--muted);
+  display: grid;
+  gap: var(--space-8);
+}
+
+.equipment-list li {
+  line-height: 1.5;
+}
+
+@media (min-width: 768px) {
+  .program-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  .equipment-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 /* STEP_3D: Carousel */
@@ -543,6 +697,48 @@ button:disabled {
   color: var(--muted);
 }
 
+.team-video {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+  align-items: flex-start;
+}
+
+.team-video__link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: 12px var(--space-24);
+  border-radius: 999px;
+  background: rgba(75, 123, 255, 0.12);
+  color: var(--brand);
+  font-weight: 600;
+  transition: transform 150ms ease, background-color 150ms ease;
+}
+
+.team-video__link:hover {
+  transform: translateY(-1px);
+  background: rgba(75, 123, 255, 0.18);
+}
+
+.team-video__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+}
+
+.team-video__icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.team-video__note {
+  margin: 0;
+  color: var(--muted);
+}
+
 /* STEP_3D: Course lead info */
 .apply-layout {
   display: grid;
@@ -670,6 +866,31 @@ button:disabled {
   padding: var(--space-16);
   color: var(--status-practice);
   font-weight: 600;
+}
+
+.form--compact {
+  max-width: 560px;
+  padding: var(--space-24);
+}
+
+.rent-form {
+  width: min(100%, 560px);
+}
+
+.form__title {
+  margin: 0;
+  font-size: var(--font-lg);
+}
+
+.rent-form__note {
+  margin: 0;
+  color: var(--muted);
+}
+
+.rent-form__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--font-xs);
 }
 
 /* STEP_3D: Accordion */


### PR DESCRIPTION
## Summary
- add shimmering hero CTA and a program overview section with an "Инженерная школа" card linking to the technopark site
- introduce an equipment and software block with a short rental form highlighting the 5 000 ₽ day rate
- surface a technopark video link under the team section and style new components for shimmer, program cards, and rentals

## Testing
- npm run lint
- npm run format:check *(fails: repository contains existing Prettier differences)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3c0e752ac83339bbaaaafb96f5005